### PR TITLE
Add 'Gtk.main()' to the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ win.setDefaultSize(200, 80)
 win.add(new Gtk.Label({ label: 'Hello Gtk+' }))
 
 win.showAll();
+Gtk.main();
 ```
 
 ![Hello node-gtk!](img/hello-node-gtk.png)


### PR DESCRIPTION
When I was checking the library out I had trouble running the example code because of the missing call to `Gtk.main()` - maybe it'll help others in the future :)