### PR TITLE
Speficy Gtk version to use

### DIFF
--- a/examples/hello-gtk.js
+++ b/examples/hello-gtk.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const GNode = require('../lib/')
-const Gtk = GNode.require('Gtk')
+const Gtk = GNode.require('Gtk', '3.0')
 
 GNode.startLoop()
 Gtk.init()


### PR DESCRIPTION
For users like me that have both Gtk 3.0 and 4.0 installed on theirs systems. It fixes this kind of errors:

```
/home/cedlemo/Projects/JavaScript/node-gtk/examples/hello-gtk.js:26                                                                                   
win.showAll();                                                                                                                                        
    ^                                                                                                                                                 
                                                                                                                                                      
TypeError: win.showAll is not a function                                                                                                              
    at Object.<anonymous> (/home/cedlemo/Projects/JavaScript/node-gtk/examples/hello-gtk.js:26:5)                                                     
    at Module._compile (internal/modules/cjs/loader.js:689:30)                                                                                        
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)                                                                          
    at Module.load (internal/modules/cjs/loader.js:599:32)                                                                                            
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)                                                                                          
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)                                                                                   
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)                                                                                
    at startup (internal/bootstrap/node.js:266:19)                                                                                                    
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)      
```

`gtk_widget_show_all` does not exist anymore in [Gtk4](https://developer.gnome.org/gtk4/3.90/GtkWidget.html#gtk-widget-show)