### PR TITLE
A basic builder example

### DIFF
--- a/examples/builder.js
+++ b/examples/builder.js
@@ -1,4 +1,5 @@
 const gi = require('../lib/index');
+const Path   = require('path');
 gi.startLoop()
 
 const Gdk          = gi.require('Gdk', '3.0');
@@ -6,7 +7,8 @@ const Gtk          = gi.require('Gtk', '3.0');
 
 Gtk.init()
 
-const builder = Gtk.Builder.newFromFile('./builderExample.glade');
+const gladeFile = Path.join(__dirname, 'builderExample.glade');
+const builder = Gtk.Builder.newFromFile(gladeFile);
 const win = builder.getObject('mainWindow');
 
 win.setDefaultSize(600, 800);

--- a/examples/builder.js
+++ b/examples/builder.js
@@ -1,0 +1,21 @@
+const gi = require('../lib/index');
+gi.startLoop()
+
+const Gdk          = gi.require('Gdk', '3.0');
+const Gtk          = gi.require('Gtk', '3.0');
+
+Gtk.init()
+
+const builder = Gtk.Builder.newFromFile('./builderExample.glade');
+const win = builder.getObject('mainWindow');
+
+win.setDefaultSize(600, 800);
+win.on('show', Gtk.main);
+
+const button = builder.getObject('closeButton');
+button.on('clicked', Gtk.mainQuit);
+
+const label = builder.getObject('helloLabel');
+label.setText('Hello World!');
+
+win.showAll();

--- a/examples/builderExample.glade
+++ b/examples/builderExample.glade
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="mainWindow">
+    <property name="can_focus">False</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="helloLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="closeButton">
+            <property name="label" translatable="yes">Close</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
#75,

This is the most basic example. There is an advanced usage where you can add action name to objects in the glade file that correspond to methods added to a `Gtk::Application` via its `Gio::Settings`, but I will try to see if it works latter. 

Tell me what kind of test you want me to do ? In [ruby-gnome](https://github.com/ruby-gnome2/ruby-gnome2/blob/master/gtk3/test/test-gtk-builder.rb), we generate a Gtk window with widgets via the builder  + a glade file and we test the type of object returned that the builder returns with `gtk_builder_get_object`. 