### PR TITLE
Updated node-gyp due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "lodash.camelcase": "4.3.0",
     "nan": "^2.10.0",
-    "node-gyp": "3.3.1",
+    "node-gyp": "^3.8.0",
     "node-pre-gyp": "0.10.2",
     "node-pre-gyp-github": "1.3.1"
   },


### PR DESCRIPTION
The node-gyp package was a few minor versions behind and had some vulnerabilities in it. Upgrading to 3.8.0 resolves the vulnerabilities 👍