### PR TITLE
fix #121: promise microtasks not called

### DIFF
--- a/examples/builder.js
+++ b/examples/builder.js
@@ -1,24 +1,57 @@
-const gi = require('../lib/index');
-const Path   = require('path');
+const fs = require('fs')
+const path   = require('path')
+const performance = require('perf_hooks').performance
+const gi = require('..')
+const Gdk = gi.require('Gdk', '3.0')
+const Gtk = gi.require('Gtk', '3.0')
+
 gi.startLoop()
-
-const Gdk          = gi.require('Gdk', '3.0');
-const Gtk          = gi.require('Gtk', '3.0');
-
 Gtk.init()
 
-const gladeFile = Path.join(__dirname, 'builderExample.glade');
-const builder = Gtk.Builder.newFromFile(gladeFile);
-const win = builder.getObject('mainWindow');
+const gladeFile = path.join(__dirname, './builderExample.glade')
+const builder = Gtk.Builder.newFromFile(gladeFile)
+const win = builder.getObject('mainWindow')
 
-win.setDefaultSize(600, 800);
-win.on('show', Gtk.main);
+win.setDefaultSize(600, 400)
+win.on('show', Gtk.main)
 win.on('destroy', Gtk.mainQuit)
 
-const button = builder.getObject('closeButton');
-button.on('clicked', () => win.close())
+const closeButton = builder.getObject('closeButton')
+closeButton.on('clicked', () => { win.close(); console.log('window closed') })
 
-const label = builder.getObject('helloLabel');
-label.setText('Hello World!');
+const actionButton = builder.getObject('actionButton')
+actionButton.on('clicked', () => {
 
-win.showAll();
+  let start = performance.now()
+
+  Promise.resolve().then(() => {
+    console.log('event promise.then() called, ' + (performance.now() - start))
+  })
+
+  process.nextTick(() => {
+    console.log('event nextTick() called, ' + (performance.now() - start))
+  })
+})
+
+const label = builder.getObject('helloLabel')
+label.setText('Hello World!')
+
+let action = function() {
+  return new Promise((resolve) => {
+    resolve('CHANGED')
+    console.log('new Promise(...)  called')
+  })
+}
+
+let start = performance.now()
+action().then(res => {
+  console.log('promise.then() called, ' + (performance.now() - start))
+  label.setText(res)
+})
+
+process.nextTick(() => {
+  console.log('nextTick() called')
+  Promise.resolve().then(() => console.log('inner promise.then() called'))
+})
+
+win.showAll()

--- a/examples/builderExample.glade
+++ b/examples/builderExample.glade
@@ -24,6 +24,19 @@
           </packing>
         </child>
         <child>
+          <object class="GtkButton" id="actionButton">
+            <property name="label" translatable="yes">Action</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkButton" id="closeButton">
             <property name="label" translatable="yes">Close</property>
             <property name="visible">True</property>
@@ -33,7 +46,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/lib/overrides/Gtk-3.0.js
+++ b/lib/overrides/Gtk-3.0.js
@@ -14,25 +14,49 @@ const internal = require('../native.js')
 
 exports.apply = (Gtk) => {
 
-    const originalMain = Gtk.main
-    const originalQuit = Gtk.mainQuit
+    /*
+     * main loop functions
+     */
+    {
 
-    let userCallingQuit = false
-    Gtk.main = function main() {
-        const loopStack = internal.GetLoopStack()
+      const originalMain = Gtk.main
+      const originalQuit = Gtk.mainQuit
 
-        loopStack.push(originalQuit)
-        originalMain()
-        if (userCallingQuit) {
-          loopStack.pop()
-        }
-        userCallingQuit = false
-    }
-    Gtk.mainQuit = function mainQuit() {
-        if (Gtk.mainLevel() === 0)
-          return
-        userCallingQuit = true
-        originalQuit()
+      let placeholderIntervalID
+      let userCallingQuit = false
+
+      Gtk.main = function main() {
+          const loopStack = internal.GetLoopStack()
+
+          /*
+           * To keep the nodejs event loop alive, we need to have something running.
+           */
+          if (placeholderIntervalID === undefined) {
+            placeholderIntervalID = setInterval(() => { /* noop */ }, 60 * 60 * 1000)
+          }
+
+          loopStack.push(originalQuit)
+
+          originalMain()
+
+          if (userCallingQuit) {
+            loopStack.pop()
+          }
+
+          userCallingQuit = false
+
+          if (Gtk.mainLevel() === 0) {
+            placeholderIntervalID = clearInterval(placeholderIntervalID)
+          }
+      }
+
+      Gtk.mainQuit = function mainQuit() {
+          if (Gtk.mainLevel() === 0)
+            return
+          userCallingQuit = true
+          originalQuit()
+      }
+
     }
 
 

--- a/src/closure.cc
+++ b/src/closure.cc
@@ -65,6 +65,8 @@ void Closure::Marshal(GClosure *base,
             else if (!V8ToGValue (g_return_value, return_value))
                 g_warning ("Marshal: could not convert return value");
         }
+
+        CallMicrotaskHandlers ();
     }
     else {
         log("'%s' did throw", g_base_info_get_name (closure->info));

--- a/src/loop.cc
+++ b/src/loop.cc
@@ -20,8 +20,6 @@ using namespace v8;
 
 namespace GNodeJS {
 
-static void CallNextTickCallback ();
-
 
 static Nan::Persistent<Array> loopStack(Nan::New<Array> ());
 

--- a/src/loop.cc
+++ b/src/loop.cc
@@ -20,6 +20,9 @@ using namespace v8;
 
 namespace GNodeJS {
 
+static void CallNextTickCallback ();
+
+
 static Nan::Persistent<Array> loopStack(Nan::New<Array> ());
 
 struct uv_loop_source {
@@ -27,7 +30,7 @@ struct uv_loop_source {
     uv_loop_t *loop;
 };
 
-static gboolean uv_loop_source_prepare (GSource *base, int *timeout) {
+static gboolean loop_source_prepare (GSource *base, int *timeout) {
     struct uv_loop_source *source = (struct uv_loop_source *) base;
     uv_update_time (source->loop);
 
@@ -49,23 +52,22 @@ static gboolean uv_loop_source_prepare (GSource *base, int *timeout) {
         return FALSE;
 }
 
-static gboolean uv_loop_source_dispatch (GSource *base, GSourceFunc callback, gpointer user_data) {
+static gboolean loop_source_dispatch (GSource *base, GSourceFunc callback, gpointer user_data) {
     struct uv_loop_source *source = (struct uv_loop_source *) base;
-    uv_run (source->loop, UV_RUN_NOWAIT);
-    Util::CallNextTickCallback();
+    uv_run (source->loop, UV_RUN_ONCE);
+    CallMicrotaskHandlers ();
     return G_SOURCE_CONTINUE;
 }
 
 static GSourceFuncs uv_loop_source_funcs = {
-    uv_loop_source_prepare,
-    NULL,
-    uv_loop_source_dispatch,
-    NULL,
-
+    /* prepare */  loop_source_prepare,
+    /* check */    NULL,
+    /* dispatch */ loop_source_dispatch,
+    /* finalize */ NULL,
     NULL, NULL,
 };
 
-static GSource *uv_loop_source_new (uv_loop_t *loop) {
+static GSource *loop_source_new (uv_loop_t *loop) {
     struct uv_loop_source *source = (struct uv_loop_source *) g_source_new (&uv_loop_source_funcs, sizeof (*source));
     source->loop = loop;
     g_source_add_unix_fd (&source->source,
@@ -74,8 +76,45 @@ static GSource *uv_loop_source_new (uv_loop_t *loop) {
     return &source->source;
 }
 
+/**
+ * This function is used to call "process._tickCallback()" inside NodeJS.
+ * We want to do this after we run the libuv eventloop because there might
+ * be pending micro-tasks from Promises or calls to 'process.nextTick()'.
+ */
+static void CallNextTickCallback() {
+    static Nan::Persistent<Object> process;
+    static Nan::Persistent<Object> tickCallback;
+
+    if (tickCallback.IsEmpty()) {
+        auto global = Nan::GetCurrentContext()->Global();
+        auto processObject = Nan::To<Object> (global->Get(UTF8("process")));
+
+        if (processObject.IsEmpty()) {
+            return;
+        }
+
+        Local<Object> processObjectChecked = processObject.ToLocalChecked();
+        Local<Value> tickCallbackValue = processObjectChecked->Get(UTF8("_tickCallback"));
+        if (!tickCallbackValue->IsFunction()) {
+            return;
+        }
+
+        process.Reset(processObjectChecked);
+        tickCallback.Reset(TO_OBJECT (tickCallbackValue));
+    }
+
+    if (!tickCallback.IsEmpty()) {
+        Nan::CallAsFunction(Nan::New<Object> (tickCallback), Nan::New<Object> (process), 0, nullptr);
+    }
+}
+
+void CallMicrotaskHandlers () {
+    CallNextTickCallback();
+    Isolate::GetCurrent()->RunMicrotasks();
+}
+
 void StartLoop() {
-    GSource *source = uv_loop_source_new (uv_default_loop ());
+    GSource *source = loop_source_new (uv_default_loop ());
     g_source_attach (source, NULL);
 }
 

--- a/src/loop.h
+++ b/src/loop.h
@@ -8,6 +8,8 @@ using namespace v8;
 
 namespace GNodeJS {
 
+  void CallMicrotaskHandlers ();
+
   void StartLoop();
 
   void QuitLoopStack();

--- a/src/util.cc
+++ b/src/util.cc
@@ -45,19 +45,4 @@ char* GetSignalName(const char* signal_detail) {
     return signal_name;
 }
 
-
-/**
- * This function is used to call "process._tickCallback()" inside NodeJS.
- * We want to do this after we run the LibUV eventloop because there might
- * be pending Micro-tasks from Promises or calls to 'process.nextTick()'.
- */
-void CallNextTickCallback() {
-    auto global = Nan::GetCurrentContext()->Global();
-    Local<Object> processObject = TO_OBJECT (global->Get(UTF8("process")));
-    Local<Value> tickCallbackValue = processObject->Get(UTF8("_tickCallback"));
-    if (tickCallbackValue->IsFunction()) {
-        Nan::CallAsFunction(TO_OBJECT (tickCallbackValue), processObject, 0, nullptr);
-    }
-}
-
 }

--- a/src/util.h
+++ b/src/util.h
@@ -12,9 +12,9 @@
 
 namespace Util
 {
-    const char*    ArrayTypeToString (GIArrayType array_type);
-    char*          GetSignalName(const char* signal_detail);
 
-    void           CallNextTickCallback();
+    const char*    ArrayTypeToString (GIArrayType array_type);
+
+    char*          GetSignalName(const char* signal_detail);
 
 } /* Util */


### PR DESCRIPTION
Closes #121 

Ok, so my guess is that given we're interrupting node's event loop mid-cycle with `gtk_main()`, node never calls microtasks because it expects to be able to do so at the end of the current cycle, but `gtk_main()` never returns until `gtk_main_quit()` is called. Anyway, I've implemented as a simple hack to have an interval timer setup by `Gtk.main()` so that nodejs keeps the loop alive (I'm really not sure of what I'm saying here but it works, but don't trust this last sentence).
I've also made sure that after event handlers, we process the nextTick queue and promise microtasks queue.

References:
 - http://docs.libuv.org/en/v1.x/design.html
 - https://blog.insiderattack.net/crossing-the-js-c-boundary-advanced-nodejs-internals-part-1-cb52957758d8
 - https://blog.insiderattack.net/new-changes-to-timers-and-microtasks-from-node-v11-0-0-and-above-68d112743eb3