### PR TITLE
Add quotes in `test / __ run __. js`

### DIFF
--- a/tests/__run__.js
+++ b/tests/__run__.js
@@ -15,7 +15,7 @@ files.forEach(file => {
     const currentTest = this
     currentTest.timeout(15000)
 
-    const cmd = `node --expose-gc ${path.join(__dirname, file)}`
+    const cmd = `node --expose-gc "${path.join(__dirname, file)}"`
     const options = {
       maxBuffer: 10 * 1024 * 1024,
     }


### PR DESCRIPTION
This is useful to prevent if the project is placed in a folder with quotes E.g `/ home / user / project's / node-gtk`.

By the way ... I skipped this, because I cloned this project in the `/ my-project's /` folder. so I get this error when run 

```bash
npm run test
```


```bash
/ bin / sh: 1: Syntax error: Unterminated quoted string
```