### PR TITLE
Override `Gtk.Builder.connectSignals`  prototype

### DIFF
--- a/examples/builder-auto-connect-signals.glade
+++ b/examples/builder-auto-connect-signals.glade
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="mainWindow">
+    <property name="can_focus">False</property>
+    <signal name="destroy" handler="onWindowDestroy" swapped="no"/>
+    <signal name="show" handler="onWindowShow" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="helloLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="actionButton">
+            <property name="label" translatable="yes">Action</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <signal name="clicked" handler="onActionBtnClicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="closeButton">
+            <property name="label" translatable="yes">Close</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <signal name="clicked" handler="onCloseBtnClicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/examples/builder-auto-connect-signals.js
+++ b/examples/builder-auto-connect-signals.js
@@ -1,0 +1,63 @@
+const fs = require('fs')
+const path   = require('path')
+const performance = require('perf_hooks').performance
+const gi = require('../lib')
+const Gdk = gi.require('Gdk', '3.0')
+const Gtk = gi.require('Gtk', '3.0')
+
+gi.startLoop()
+Gtk.init()
+
+const gladeFile = path.join(__dirname, './builder-auto-connect-signals.glade')
+const builder = Gtk.Builder.newFromFile(gladeFile)
+const win = builder.getObject('mainWindow')
+
+win.setDefaultSize(600, 400)
+
+const handlers = {}
+
+handlers.onWindowShow = Gtk.main
+handlers.onWindowDestroy = Gtk.mainQuit
+
+handlers.onCloseBtnClicked = function () {
+  win.close()
+  console.log('window closed')
+}
+
+handlers.onBtnActionClicked = function () {
+  let start = performance.now()
+
+  Promise.resolve().then(() => {
+    console.log('event promise.then() called, ' + (performance.now() - start))
+  })
+
+  process.nextTick(() => {
+    console.log('event nextTick() called, ' + (performance.now() - start))
+  })
+}
+
+// Connect to signals that specified on glade file
+builder.connectSignals(handlers)
+
+const label = builder.getObject('helloLabel')
+label.setText('Hello World!')
+
+let action = function() {
+  return new Promise((resolve) => {
+    resolve('CHANGED')
+    console.log('new Promise(...)  called')
+  })
+}
+
+let start = performance.now()
+action().then(res => {
+  console.log('promise.then() called, ' + (performance.now() - start))
+  label.setText(res)
+})
+
+process.nextTick(() => {
+  console.log('nextTick() called')
+  Promise.resolve().then(() => console.log('inner promise.then() called'))
+})
+
+win.showAll()

--- a/examples/builder-auto-connect-signals.js
+++ b/examples/builder-auto-connect-signals.js
@@ -1,8 +1,5 @@
-const fs = require('fs')
 const path   = require('path')
-const performance = require('perf_hooks').performance
 const gi = require('../lib')
-const Gdk = gi.require('Gdk', '3.0')
 const Gtk = gi.require('Gtk', '3.0')
 
 gi.startLoop()
@@ -10,54 +7,26 @@ Gtk.init()
 
 const gladeFile = path.join(__dirname, './builder-auto-connect-signals.glade')
 const builder = Gtk.Builder.newFromFile(gladeFile)
-const win = builder.getObject('mainWindow')
 
-win.setDefaultSize(600, 400)
-
-const handlers = {}
-
-handlers.onWindowShow = Gtk.main
-handlers.onWindowDestroy = Gtk.mainQuit
-
-handlers.onCloseBtnClicked = function () {
-  win.close()
-  console.log('window closed')
-}
-
-handlers.onBtnActionClicked = function () {
-  let start = performance.now()
-
-  Promise.resolve().then(() => {
-    console.log('event promise.then() called, ' + (performance.now() - start))
-  })
-
-  process.nextTick(() => {
-    console.log('event nextTick() called, ' + (performance.now() - start))
-  })
+const handlers = {
+  onWindowShow: Gtk.main,
+  onWindowDestroy: Gtk.mainQuit,
+  onCloseBtnClicked: function () {
+    win.close()
+    console.log('window closed')
+  },
+  onActionBtnClicked: function () {
+    console.log('button clicked')
+  }
 }
 
 // Connect to signals that specified on glade file
 builder.connectSignals(handlers)
 
+const win = builder.getObject('mainWindow')
+win.setDefaultSize(600, 400)
+
 const label = builder.getObject('helloLabel')
 label.setText('Hello World!')
-
-let action = function() {
-  return new Promise((resolve) => {
-    resolve('CHANGED')
-    console.log('new Promise(...)  called')
-  })
-}
-
-let start = performance.now()
-action().then(res => {
-  console.log('promise.then() called, ' + (performance.now() - start))
-  label.setText(res)
-})
-
-process.nextTick(() => {
-  console.log('nextTick() called')
-  Promise.resolve().then(() => console.log('inner promise.then() called'))
-})
 
 win.showAll()

--- a/lib/overrides/Gtk-3.0.js
+++ b/lib/overrides/Gtk-3.0.js
@@ -99,4 +99,16 @@ exports.apply = (Gtk) => {
     return object
   }
 
+  /**
+   * Gtk.Builder.prototype.connectSignals
+   * @returns void
+   */
+  Gtk.Builder.prototype.connectSignals = function(handlers) {
+    if (!handlers) return
+    this.connectSignalsFull(function (builder, object, signal, handler) {
+      if (handlers[handler] && typeof handlers[handler] == 'function') {
+        object.connect(signal, handlers[handler])
+      }
+    })
+  }
 }


### PR DESCRIPTION
This is inspired by PyGobject API. 
Maybe this is one of the many ways to fix this issue #140  .I'm not sure about this yet. So I want you to review this and maybe there is a better way than this. 
For an example of this API, I will make it later. or you can make it (if you have time) :open_hands: 