### PR TITLE
using const instead let

### DIFF
--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -627,7 +627,7 @@ function formatName(info) {
 }
 
 function formatFunction(fn) {
-    let parent = formatName(fn.parent)
+    const parent = formatName(fn.parent)
 
     return (
         (parent ? chalk.yellow(parent) + chalk.grey('.') : '')


### PR DESCRIPTION
Because the `parent` variable is only assigned once, we use` const` instead of `let` maybe better.