### PR TITLE
Fix callback return referencing

### DIFF
--- a/src/callback.cc
+++ b/src/callback.cc
@@ -111,7 +111,7 @@ void Callback::Call (ffi_cif *cif, void *result, void **args, gpointer user_data
 
         bool didConvert = V8ToGIArgument (
                 &type_info,
-                (GIArgument *) &result,
+                (GIArgument *) result,
                 return_value.ToLocalChecked(),
                 g_callable_info_may_return_null (callback->info));
 


### PR DESCRIPTION
Fixes #187 

It seems too easy. In the example of #187 the return value of the callback is not written due to the wrong pointer value.