### PR TITLE
Automatically unpack GValue results

### DIFF
--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -421,6 +421,11 @@ Local<Value> WrapperFromBoxed(GIBaseInfo *info, void *data, bool mustCopy) {
     if (data == NULL)
         return Nan::Null();
 
+    GType gtype = g_registered_type_info_get_g_type ((GIRegisteredTypeInfo *) info);
+    if (g_type_is_a(gtype, G_TYPE_VALUE)) {
+        return GValueToV8(reinterpret_cast<const GValue *>(data), mustCopy);
+    }
+
     Local<Function> constructor = MakeBoxedClass (info);
 
     Local<Value> boxed_external = Nan::New<External> (data);

--- a/tests/gvalue__return.js
+++ b/tests/gvalue__return.js
@@ -1,11 +1,7 @@
-/*
- * gvalue__return.js
- */
-
 const gi = require('../lib/')
-const Gst = gi.require('Gst')
-const GObject = gi.require('GObject')
-const { assert, describe, expect, it } = require('./__common__.js')
+const Gst = gi.require('Gst', '1.0')
+const GObject = gi.require('GObject', '2.0')
+const { describe, expect, it } = require('./__common__.js')
 
 gi.startLoop()
 Gst.init()

--- a/tests/gvalue__return.js
+++ b/tests/gvalue__return.js
@@ -1,7 +1,7 @@
 const gi = require('../lib/')
 const Gst = gi.require('Gst', '1.0')
 const GObject = gi.require('GObject', '2.0')
-const { describe, expect, it } = require('./__common__.js')
+const { assert, describe, expect, it } = require('./__common__.js')
 
 gi.startLoop()
 Gst.init()
@@ -9,11 +9,17 @@ Gst.init()
 function initStructure() {
   const struct = Gst.Structure.newEmpty('name')
 
-  // initialize GValue of type G_TYPE_STRING
   const val0 = new GObject.Value()
-  val0.init(16 << 2)
+  val0.init(GObject.TYPE_STRING)
   val0.setString('okay')
-  struct.setValue('key', val0)
+  struct.setValue('msg', val0)
+
+  const val1 = new GObject.Value()
+  val1.init(GObject.TYPE_OBJECT)
+
+  const pad = new Gst.Pad()
+  val1.setObject(pad)
+  struct.setValue('pad', val1)
 
   return struct
 }
@@ -22,8 +28,12 @@ describe('return values of type GValue are converted automatically', () => {
   it('should not return a GValue', () => {
     const struct = initStructure()
 
-    const msg = struct.getValue('key')
+    const msg = struct.getValue('msg')
     expect(msg, 'okay')
     expect(typeof msg, 'string')
+
+    const pad = struct.getValue('pad')
+    assert(pad instanceof Gst.Pad)
+    expect(pad.getName(), 'pad0')
   })
 })

--- a/tests/gvalue__return.js
+++ b/tests/gvalue__return.js
@@ -1,0 +1,33 @@
+/*
+ * gvalue__return.js
+ */
+
+const gi = require('../lib/')
+const Gst = gi.require('Gst')
+const GObject = gi.require('GObject')
+const { assert, describe, expect, it } = require('./__common__.js')
+
+gi.startLoop()
+Gst.init()
+
+function initStructure() {
+  const struct = Gst.Structure.newEmpty('name')
+
+  // initialize GValue of type G_TYPE_STRING
+  const val0 = new GObject.Value()
+  val0.init(16 << 2)
+  val0.setString('okay')
+  struct.setValue('key', val0)
+
+  return struct
+}
+
+describe('return values of type GValue are converted automatically', () => {
+  it('should not return a GValue', () => {
+    const struct = initStructure()
+
+    const msg = struct.getValue('key')
+    expect(msg, 'okay')
+    expect(typeof msg, 'string')
+  })
+})


### PR DESCRIPTION
I propose to automatically unpack `GValue`s which are returned from functions.
The PR may introduce some side-effects as automatic unpacking might not be the expected in every use case. Please let me know if you see any issues.

Fixes #203 