### PR TITLE
Redefine setProperty of GObject

### DIFF
--- a/lib/overrides/GObject.js
+++ b/lib/overrides/GObject.js
@@ -39,4 +39,8 @@ exports.apply = (GObject) => {
   GObject.Object.prototype.setProperty = function (name, value) {
     gi._c.ObjectPropertySetter(this, name, value)
   }
+  GObject.Object.prototype._getProperty = GObject.Object.prototype.getProperty
+  GObject.Object.prototype.getProperty = function (name) {
+    return gi._c.ObjectPropertyGetter(this, name)
+  }
 }

--- a/lib/overrides/GObject.js
+++ b/lib/overrides/GObject.js
@@ -2,6 +2,7 @@
  * GObject.js
  */
 
+const gi = require('..')
 
 exports.apply = (GObject) => {
 
@@ -33,4 +34,9 @@ exports.apply = (GObject) => {
   GObject.TYPE_GTYPE     = GObject.typeFromName('GType')
   GObject.TYPE_VARIANT   = GObject.typeFromName('GVariant')
   GObject.TYPE_UNICHAR   = GObject.TYPE_UINT
+
+  GObject.Object.prototype._setProperty = GObject.Object.prototype.setProperty
+  GObject.Object.prototype.setProperty = function (name, value) {
+    gi._c.ObjectPropertySetter(this, name, value)
+  }
 }


### PR DESCRIPTION
Here's the second proposal to solve my issue #183.
After the update it is easy to set properties of non-introspected objects using the `setProperty` function. The original `setProperty` function takes an `GValue` as second argument which is not very practical use from JS.