### PR TITLE
GObject: Implement get/set of non-introspected properties

### DIFF
--- a/src/gi.cc
+++ b/src/gi.cc
@@ -182,20 +182,7 @@ NAN_METHOD(ObjectPropertyGetter) {
     Nan::Utf8String prop_name_v (TO_STRING (info[1]));
     const char *prop_name = *prop_name_v;
 
-    GParamSpec *pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (gobject), prop_name);
-
-    if (pspec == NULL) {
-        WARN("ObjectPropertyGetter: no property %s", prop_name);
-        return;
-    }
-
-    GValue value = G_VALUE_INIT;
-    g_value_init (&value, G_PARAM_SPEC_VALUE_TYPE (pspec));
-    g_object_get_property (gobject, prop_name, &value);
-
-    RETURN(GNodeJS::GValueToV8(&value, true));
-
-    g_value_unset(&value);
+    RETURN(GNodeJS::GetGObjectProperty(gobject, prop_name));
 }
 
 NAN_METHOD(ObjectPropertySetter) {
@@ -208,25 +195,7 @@ NAN_METHOD(ObjectPropertySetter) {
         RETURN(Nan::False());
     }
 
-    GParamSpec *pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (gobject), prop_name);
-
-    if (pspec == NULL) {
-        WARN("ObjectPropertySetter: no property %s", prop_name);
-        Nan::ThrowError("Unexistent property");
-        return;
-    }
-
-    GValue value = G_VALUE_INIT;
-    g_value_init(&value, G_PARAM_SPEC_VALUE_TYPE (pspec));
-
-    if (GNodeJS::V8ToGValue (&value, info[2], true)) {
-        g_object_set_property (gobject, prop_name, &value);
-        RETURN(Nan::True());
-    } else {
-        RETURN(Nan::False());
-    }
-
-    g_value_unset(&value);
+    RETURN(GNodeJS::SetGObjectProperty(gobject, prop_name, info[2]));
 }
 
 NAN_METHOD(StructFieldSetter) {

--- a/src/gobject.h
+++ b/src/gobject.h
@@ -6,6 +6,7 @@
 #include <girepository.h>
 #include <glib-object.h>
 
+using v8::Boolean;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Local;
@@ -19,5 +20,7 @@ MaybeLocal<Function>    MakeClass            (GIBaseInfo *info);
 Local<Value>            WrapperFromGObject   (GObject *object);
 GObject *               GObjectFromWrapper   (Local<Value> value);
 Local<FunctionTemplate> GetBaseClassTemplate ();
+Local<Value>            GetGObjectProperty   (GObject * gobject, const char *prop_name);
+Local<Boolean>          SetGObjectProperty   (GObject * gobject, const char *prop_name, Local<Value> value);
 
 };

--- a/src/util.cc
+++ b/src/util.cc
@@ -45,4 +45,22 @@ char* GetSignalName(const char* signal_detail) {
     return signal_name;
 }
 
+char* ToDashed(const char* camel_case) {
+    // Over-allocate; in the worst case the string become 2 times as long.
+    char* dashed = (char*)g_malloc((strlen(camel_case) * 2) + 1);
+
+    int j = 0;
+    for (int i = 0; camel_case[i] != '\0'; i++) {
+        if (isupper(camel_case[i])) {
+            dashed[j++] = '-';
+            dashed[j++] = tolower(camel_case[i]);
+        } else {
+            dashed[j++] = camel_case[i];
+        }
+    }
+
+    dashed[j++] = '\0';
+    return dashed;
+}
+
 }

--- a/src/util.h
+++ b/src/util.h
@@ -58,4 +58,6 @@ namespace Util
 
     char*          GetSignalName(const char* signal_detail);
 
+    char*          ToDashed(const char* camel_case);
+
 } /* Util */

--- a/tests/object__non-introspected.js
+++ b/tests/object__non-introspected.js
@@ -21,7 +21,7 @@ describe('create introspected objected', () => {
 })
 
 describe('create non-introspected objected', () => {
-  const src = Gst.ElementFactory.make('videotestsrc')
+  const src = Gst.ElementFactory.make('videotestsrc', 'src')
   expect(src.constructor.name, 'GstVideoTestSrc')
   expect(typeof src.addPad, 'function')
 
@@ -30,5 +30,25 @@ describe('create non-introspected objected', () => {
     assert(src instanceof Gst.Object)
     assert(src instanceof GObject.InitiallyUnowned)
     assert(src instanceof GObject.Object)
+  })
+
+  it('has introspected properties', () => {
+    expect(src.name, 'src');
+  })
+
+  it('has non-introspected properties', () => {
+    expect(src.pattern, 0)
+    expect(src.timestampOffset, 0)
+    expect(src.isLive, false)
+  })
+
+  it('does not have dashed properties', () => {
+    expect(src['is-live'], undefined);
+  })
+
+  it('correctly pass-through non-gobject propertties', () => {
+    expect(src.notAVideoTestSrcProperty, undefined)
+    src.notAVideoTestSrcProperty = '42';
+    expect(src.notAVideoTestSrcProperty, '42')
   })
 })


### PR DESCRIPTION
This commit implements a NamedPropertyHandler which enable get/set of
non-introspected properties. This is done by re-factoring ObjectProperty
{Getter,Setter} to seperate actual property handling to helper functions
under gobject.cc, then implement the handler using those functions.

The handler uses kNonMasking flag, which make V8 skips the handler if
the object already has the property. This flag is available in Node.js >=
v4.x [1], but I believe we don't have to care about Node.js that old.

Fixes #83. Also fixes partially #183.

[1] https://github.com/nodejs/nan/issues/667#issuecomment-298598348