### PR TITLE
Fix handling of GQuarks in Error test

### DIFF
--- a/tests/error.js
+++ b/tests/error.js
@@ -10,6 +10,8 @@ const common = require('./__common__.js')
 
 Gst.init()
 
+const QUARK_STRING = 'example'
+const CUSTOM_QUARK = GLib.quarkFromString(QUARK_STRING)
 const ERROR_MESSAGE = 'ERROR_MESSAGE'
 const ERROR_CODE = 42
 const DEBUG_STRING = 'debug string'
@@ -17,12 +19,13 @@ const DEBUG_STRING = 'debug string'
 common.describe('GError', () => {
   common.it('should be returned', () => {
     common.assert(GLib.Error !== undefined)
-    const err0 = GLib.Error.newLiteral(404, ERROR_CODE, ERROR_MESSAGE)
+    const err0 = GLib.Error.newLiteral(CUSTOM_QUARK, ERROR_CODE, ERROR_MESSAGE)
     common.assert(err0.code === ERROR_CODE && err0.message === ERROR_MESSAGE)
 
     const msg = Gst.Message.newError(null, err0, DEBUG_STRING)
     const [err1, debugString] = msg.parseError();
     common.assert(err1.code === ERROR_CODE && err1.message === ERROR_MESSAGE)
     common.assert(debugString === DEBUG_STRING)
+    common.assert(GLib.quarkToString(err1.domain) === QUARK_STRING)
   })
 })

--- a/tests/error.js
+++ b/tests/error.js
@@ -6,7 +6,7 @@
 const gi = require('../lib/')
 const GLib = gi.require('GLib', '2.0')
 const Gst = gi.require('Gst', '1.0')
-const { describe, it, assert } = require('./__common__.js')
+const { describe, it, assert, expect } = require('./__common__.js')
 
 Gst.init()
 
@@ -17,15 +17,25 @@ const ERROR_CODE = 42
 const DEBUG_STRING = 'debug string'
 
 describe('GError', () => {
-  it('should be returned', () => {
+  it('should exist', () => {
     assert(GLib.Error !== undefined, 'Error is not available')
-    const err0 = GLib.Error.newLiteral(CUSTOM_QUARK, ERROR_CODE, ERROR_MESSAGE)
-    assert(err0.code === ERROR_CODE && err0.message === ERROR_MESSAGE, 'code or message is not accessible')
+  })
 
+  it('should be created from literal', () => {
+    const err = GLib.Error.newLiteral(CUSTOM_QUARK, ERROR_CODE, ERROR_MESSAGE)
+    expect(err.domain, CUSTOM_QUARK)
+    expect(err.code, ERROR_CODE)
+    expect(err.message, ERROR_MESSAGE)
+  })
+
+  it('should be returned from parseError', () => {
+    const err0 = GLib.Error.newLiteral(CUSTOM_QUARK, ERROR_CODE, ERROR_MESSAGE)
     const msg = Gst.Message.newError(null, err0, DEBUG_STRING)
-    const [err1, debugString] = msg.parseError();
-    assert(err1.code === ERROR_CODE && err1.message === ERROR_MESSAGE, 'code or message is not equal')
-    assert(debugString === DEBUG_STRING, 'debug string is not returned')
-    assert(err1.domain === CUSTOM_QUARK && GLib.quarkToString(err1.domain) === QUARK_STRING, 'domain does not match')
+    const [err1, debugString] = msg.parseError()
+    expect(err1.domain, CUSTOM_QUARK)
+    expect(err1.code, ERROR_CODE)
+    expect(err1.message, ERROR_MESSAGE)
+    expect(debugString, DEBUG_STRING)
+    expect(GLib.quarkToString(err1.domain), QUARK_STRING)
   })
 })

--- a/tests/error.js
+++ b/tests/error.js
@@ -6,7 +6,7 @@
 const gi = require('../lib/')
 const GLib = gi.require('GLib', '2.0')
 const Gst = gi.require('Gst', '1.0')
-const common = require('./__common__.js')
+const { describe, it, assert } = require('./__common__.js')
 
 Gst.init()
 
@@ -16,16 +16,16 @@ const ERROR_MESSAGE = 'ERROR_MESSAGE'
 const ERROR_CODE = 42
 const DEBUG_STRING = 'debug string'
 
-common.describe('GError', () => {
-  common.it('should be returned', () => {
-    common.assert(GLib.Error !== undefined)
+describe('GError', () => {
+  it('should be returned', () => {
+    assert(GLib.Error !== undefined, 'Error is not available')
     const err0 = GLib.Error.newLiteral(CUSTOM_QUARK, ERROR_CODE, ERROR_MESSAGE)
-    common.assert(err0.code === ERROR_CODE && err0.message === ERROR_MESSAGE)
+    assert(err0.code === ERROR_CODE && err0.message === ERROR_MESSAGE, 'code or message is not accessible')
 
     const msg = Gst.Message.newError(null, err0, DEBUG_STRING)
     const [err1, debugString] = msg.parseError();
-    common.assert(err1.code === ERROR_CODE && err1.message === ERROR_MESSAGE)
-    common.assert(debugString === DEBUG_STRING)
-    common.assert(GLib.quarkToString(err1.domain) === QUARK_STRING)
+    assert(err1.code === ERROR_CODE && err1.message === ERROR_MESSAGE, 'code or message is not equal')
+    assert(debugString === DEBUG_STRING, 'debug string is not returned')
+    assert(err1.domain === CUSTOM_QUARK && GLib.quarkToString(err1.domain) === QUARK_STRING, 'domain does not match')
   })
 })


### PR DESCRIPTION
According to https://github.com/romgrk/node-gtk/pull/225#discussion_r513235539 `GQuark`s should be registered. I did not respect this rule in the original test.