### PR TITLE
Remove using v8::Boolean

### DIFF
--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -15,7 +15,6 @@
 #include "modules/cairo/cairo.h"
 
 using v8::Array;
-using v8::Boolean;
 using v8::External;
 using v8::Function;
 using v8::FunctionTemplate;
@@ -424,7 +423,7 @@ Local<Value> WrapperFromBoxed(GIBaseInfo *info, void *data, bool mustCopy) {
     Local<Function> constructor = MakeBoxedClass (info);
 
     Local<Value> boxed_external = Nan::New<External> (data);
-    Local<Value> must_copy_value = Nan::New<Boolean> (mustCopy);
+    Local<Value> must_copy_value = Nan::New<v8::Boolean> (mustCopy);
     Local<Value> args[] = { boxed_external, must_copy_value };
 
     MaybeLocal<Object> instance = Nan::NewInstance(constructor, 2, args);

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -14,7 +14,6 @@
 #include "value.h"
 
 using v8::Array;
-using v8::Boolean;
 using v8::External;
 using v8::Function;
 using v8::FunctionTemplate;
@@ -618,15 +617,15 @@ Local<Value> GetGObjectProperty(GObject * gobject, const char *prop_name) {
     return ret;
 }
 
-Local<Boolean> SetGObjectProperty(GObject * gobject, const char *prop_name, Local<Value> value) {
+Local<v8::Boolean> SetGObjectProperty(GObject * gobject, const char *prop_name, Local<Value> value) {
     GParamSpec *pspec = g_object_class_find_property (G_OBJECT_GET_CLASS (gobject), prop_name);
 
     if (pspec == NULL) {
         Nan::ThrowError("Unexistent property");
-        return Local<Boolean> ();
+        return Local<v8::Boolean> ();
     }
 
-    Local<Boolean> ret;
+    Local<v8::Boolean> ret;
 
     GValue gvalue = G_VALUE_INIT;
     g_value_init(&gvalue, G_PARAM_SPEC_VALUE_TYPE (pspec));

--- a/src/gobject.h
+++ b/src/gobject.h
@@ -6,7 +6,6 @@
 #include <girepository.h>
 #include <glib-object.h>
 
-using v8::Boolean;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Local;
@@ -21,6 +20,6 @@ Local<Value>            WrapperFromGObject   (GObject *object);
 GObject *               GObjectFromWrapper   (Local<Value> value);
 Local<FunctionTemplate> GetBaseClassTemplate ();
 Local<Value>            GetGObjectProperty   (GObject * gobject, const char *prop_name);
-Local<Boolean>          SetGObjectProperty   (GObject * gobject, const char *prop_name, Local<Value> value);
+Local<v8::Boolean>          SetGObjectProperty   (GObject * gobject, const char *prop_name, Local<Value> value);
 
 };

--- a/src/value.cc
+++ b/src/value.cc
@@ -19,7 +19,6 @@
 
 using v8::Array;
 using v8::TypedArray;
-using v8::Boolean;
 using v8::Integer;
 using v8::Local;
 using v8::Number;
@@ -44,7 +43,7 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
     case GI_TYPE_TAG_VOID:
         return Nan::Undefined ();
     case GI_TYPE_TAG_BOOLEAN:
-        return New<Boolean>((bool)arg->v_boolean);
+        return New<v8::Boolean>((bool)arg->v_boolean);
     case GI_TYPE_TAG_INT32:
         return New<v8::Int32> (arg->v_int);
     case GI_TYPE_TAG_UINT32:
@@ -1267,7 +1266,7 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, bool mustCopy) {
 Local<Value> GValueToV8(const GValue *gvalue, bool mustCopy) {
     // by-value types
     if (G_VALUE_HOLDS_BOOLEAN (gvalue)) {
-        return New<Boolean>(g_value_get_boolean (gvalue));
+        return New<v8::Boolean>(g_value_get_boolean (gvalue));
     } else if (G_VALUE_HOLDS_CHAR (gvalue)) {
         return New<Integer>(g_value_get_schar (gvalue));
     } else if (G_VALUE_HOLDS_UCHAR (gvalue)) {


### PR DESCRIPTION
We were having issue building on macOS because the name `Boolean` was exposed by `using v8::Boolean;`.
I fixed it by using `v8::Boolean` explicitly at the corresponding places.
Now it compiles successfully on the recent beta of Big Sur.

I am still waiting for the tests to pass.

Fixes #217 