### PR TITLE
Add brew dependencies to ensure that webrtcbin is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
 - export PATH=./node_modules/.bin/:$PATH
 - if [[ $(uname -s) == 'Darwin' ]]; then
     clang --version;
-    brew install gtk+3 gobject-introspection glib libsoup cairo gstreamer gst-plugins-base gst-plugins-bad;
+    brew install gtk+3 gobject-introspection glib libsoup cairo gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad libnice;
   fi;
 
 before_script:


### PR DESCRIPTION
It is not a good solution. But at least it fixes the test. In the long term we should replace the callback test to get rid of the dependencies.

Fixes #232.