### PR TITLE
expose cairo_image_surface_create_for_data

### DIFF
--- a/src/modules/cairo/generator.js
+++ b/src/modules/cairo/generator.js
@@ -416,6 +416,9 @@ function getInArgumentSource(p, n) {
 
   if (typeName === 'const char *')
     return `Nan::Utf8String ${p.name}__value(info[${n}].As<String>()); auto ${p.name} = *${p.name}__value;`
+  
+  if (typeName === 'unsigned char *' || typeName === 'const unsigned char *')
+    return (`if (!node::Buffer::HasInstance(info[${n}])) return Nan::ThrowTypeError("buffer expected"); auto ${p.name} = (unsigned char *) node::Buffer::Data(info[${n}]);`)
 
   if (baseName in ENUM_TYPE)
     return `auto ${p.name} = (${typeName}) Nan::To<${ENUM_TYPE[typeName]}>(info[${n}].As<Number>()).ToChecked();`

--- a/src/modules/cairo/surface.cc
+++ b/src/modules/cairo/surface.cc
@@ -142,6 +142,7 @@ void ImageSurface::SetupTemplate(Local<FunctionTemplate> parentTpl) {
   auto ctor = Nan::GetFunction (tpl).ToLocalChecked();
 
   SET_METHOD(ctor, createFromPng);
+  SET_METHOD(ctor, createForData);
 
   constructorTemplate.Reset(tpl);
   constructor.Reset(ctor);
@@ -634,6 +635,24 @@ NAN_METHOD(ImageSurface::createFromPng) {
 
   // function call
   cairo_surface_t * result = cairo_image_surface_create_from_png (filename);
+
+  // return
+  Local<Value> args[] = { Nan::New<External> (result) };
+  Local<Function> constructor = Nan::New<Function> (Surface::constructor);
+  Local<Value> returnValue = Nan::NewInstance(constructor, 1, args).ToLocalChecked();
+  info.GetReturnValue().Set(returnValue);
+}
+
+NAN_METHOD(ImageSurface::createForData) {
+  // in-arguments
+  if (!node::Buffer::HasInstance(info[0])) return Nan::ThrowTypeError("buffer expected"); auto data = (unsigned char *) node::Buffer::Data(info[0]);
+  auto format = (cairo_format_t) Nan::To<int64_t>(info[1].As<Number>()).ToChecked();
+  auto width = Nan::To<int64_t>(info[2].As<Number>()).ToChecked();
+  auto height = Nan::To<int64_t>(info[3].As<Number>()).ToChecked();
+  auto stride = Nan::To<int64_t>(info[4].As<Number>()).ToChecked();
+
+  // function call
+  cairo_surface_t * result = cairo_image_surface_create_for_data (data, format, width, height, stride);
 
   // return
   Local<Value> args[] = { Nan::New<External> (result) };

--- a/src/modules/cairo/surface.h
+++ b/src/modules/cairo/surface.h
@@ -70,6 +70,7 @@ class ImageSurface: public Surface {
     static NAN_METHOD(New);
 
     static NAN_METHOD(createFromPng);
+    static NAN_METHOD(createForData);
     static NAN_METHOD(getData);
     static NAN_METHOD(getFormat);
     static NAN_METHOD(getWidth);

--- a/src/modules/cairo/surface.nid
+++ b/src/modules/cairo/surface.nid
@@ -60,7 +60,7 @@ namespace ImageSurface {
 
 [[constructor]] cairo_surface_t * cairo_image_surface_create (cairo_format_t format, int width, int height);
 [[static]] cairo_surface_t * cairo_image_surface_create_from_png (const char *filename);
-/* cairo_surface_t * cairo_image_surface_create_for_data (unsigned char *data, cairo_format_t format, int width, int height, int stride); */
+[[static]] cairo_surface_t * cairo_image_surface_create_for_data (unsigned char *data, cairo_format_t format, int width, int height, int stride);
 [[returns(uint8_t *)]] unsigned char * cairo_image_surface_get_data (cairo_surface_t *surface);
 cairo_format_t cairo_image_surface_get_format (cairo_surface_t *surface);
 int cairo_image_surface_get_width (cairo_surface_t *surface);


### PR DESCRIPTION
node-gtk is really great, thank you :blue_heart:

AFAIK, the only current way to create an ImageSurface is from a PNG, and it has to be a file in the disk.
This PR exposes the `cairo_image_surface_create_for_data` function.
I would be really grateful if we could make it happen, since that would allow:

 - Retrieving the image from other sources, i.e. http, etc.
 - Working with other image formats (i.e. decode a JPEG image using a separate module, then use the resulting pixels)
 - Painting directly onto user's buffer.
 - Collecting pixel data from other surfaces (i.e. to implement screenshot functionality).
 - Rendering a user's buffer into a widget.

The function is low-level (the user is responsible of allocating a large enough buffer for their width, height & format; the user is responsible of holding that buffer alive as long as the image surface is used; etc.)