### PR TITLE
Wrap timer functions in try/catch

### DIFF
--- a/lib/loop.js
+++ b/lib/loop.js
@@ -35,10 +35,19 @@ function start() {
 // Helpers
 
 function wrappedLoopFunction(fn) {
-  return (...args) => {
+  return (callback, ...rest) => {
     process._tickCallback()
-    return fn(...args)
+    return fn(tryCallback(callback), ...rest)
   }
 }
 
-
+function tryCallback(fn) {
+  return (...args) => {
+    try {
+      return fn(...args)
+    } catch (err) {
+      console.error(err)
+      process.exit(1)
+    }
+  }
+}


### PR DESCRIPTION
This is another patch on our event loop issues, it should be removed when we're handling things more cleanly.

Link: #273

Edit: for the record, this is required because otherwise if an error occurs within a timer callback, nodejs crashes with an `Error: async hook stack has become corrupted`.