### PR TITLE
fix(GObject): don't set gobject properties from dashed property names

### DIFF
--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -230,6 +230,12 @@ static void GObjectFallbackPropertySetter (Local<v8::Name> property, Local<Value
 
     Nan::Utf8String prop_name_v (TO_STRING (property));
     const char *prop_name_camel = *prop_name_v;
+
+    if (strstr(prop_name_camel, "-")) {
+        // Has dash, not a camel-case property name.
+        return;
+    }
+
     char *prop_name = Util::ToDashed(prop_name_camel);
 
     if (gobject == NULL) {

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -246,8 +246,8 @@ static void GObjectFallbackPropertySetter (Local<v8::Name> property, Local<Value
 
     auto setResult = SetGObjectProperty(gobject, prop_name, value);
     if (setResult.IsEmpty()) {
-        // Non-existent property. We catch the exception and consider the set
-        // not intercepted by not setting return value;
+        // Non-existent property. Let node consider the set not intercepted
+        // by not setting return value;
     } else {
         // Property exists. Whether we can convert the value and set the
         // property or not, consider the set intercepted.

--- a/tests/object__non-introspected.js
+++ b/tests/object__non-introspected.js
@@ -46,6 +46,12 @@ describe('create non-introspected objected', () => {
     expect(src['is-live'], undefined);
   })
 
+  it('does not set gobject properties from dashed property names', () => {
+    expect(src.isLive, false)
+    src['is-live'] = true
+    expect(src.isLive, false)
+  })
+
   it('correctly pass-through non-gobject propertties', () => {
     expect(src.notAVideoTestSrcProperty, undefined)
     src.notAVideoTestSrcProperty = '42';


### PR DESCRIPTION
Restore dashed property check in `GObjectFallbackPropertySetter()` which
is removed in commit 03ff4ad ("fix(GObject): dont throw/catch when
setting properties"), and add a test case to ensure the correctness in
this case.

While we're at it, remove a stale reference to exception inside `GObjectFallbackPropertySetter()` in a separate commit.