### PR TITLE
(better) support for typed arrays

### DIFF
--- a/tests/conversion__array.js
+++ b/tests/conversion__array.js
@@ -17,6 +17,20 @@ describe('IN-array', () => {
   assert(result === Buffer.from('hello').toString('base64'))
 })
 
+describe('IN-array (Uint8Array)', () => {
+  const data = Uint8Array.from([ 104, 101, 108, 108, 111 ]) // hello
+  const result = glib.base64Encode(data, data.length)
+  console.log('Result:', result)
+  assert(result === Buffer.from('hello').toString('base64'))
+})
+
+describe('IN-array (Int8Array)', () => {
+  const data = Int8Array.from([ 104, 101, 108, 108, 111 ]) // hello
+  const result = glib.base64Encode(data, data.length)
+  console.log('Result:', result)
+  assert(result === Buffer.from('hello').toString('base64'))
+})
+
 describe('OUT-array (array-length after)', () => {
   const data = [ 104, 101, 108, 108, 111 ] // hello
   const result = glib.computeChecksumForData(glib.ChecksumType.MD5, data)

--- a/tests/conversion__array.js
+++ b/tests/conversion__array.js
@@ -43,14 +43,13 @@ describe('OUT-array (array-length after)', () => {
 
 describe('OUT-array (array-length before)', () => {
   const filepath = path.join(__dirname, 'lorem-ipsum.txt')
-  const result = glib.fileGetContents(filepath)
-  console.log('Result:', result)
-  const content = result[1].map(c => String.fromCharCode(c)).join('')
-  const actualContent = fs.readFileSync(filepath).toString()
+  const [ ok, content ] = glib.fileGetContents(filepath)
+  const actualContent = fs.readFileSync(filepath)
 
   console.log([content, actualContent])
-  assert(result[0] === true, 'glib_file_get_contents failed')
-  assert(content === actualContent, 'file content is wrong')
+  assert(ok === true, 'glib_file_get_contents failed')
+  assert(content instanceof Uint8Array, 'did not return Uint8Array')
+  assert(actualContent.equals(content), 'file content is wrong')
 })
 
 describe('OUT-array (zero-terminated)', () => {

--- a/tests/function_call__out.js
+++ b/tests/function_call__out.js
@@ -6,7 +6,7 @@
 const gi = require('../lib/')
 const Gtk = gi.require('Gtk', '3.0')
 const GLib = gi.require('GLib')
-const { describe, it, expect } = require('./__common__.js')
+const { describe, it, expect, assert } = require('./__common__.js')
 
 gi.startLoop()
 Gtk.init()
@@ -28,9 +28,10 @@ describe('function out parameters', () => {
     const data = 'aGVsbG8='
     const result = GLib.base64Decode(data, data.length)
     console.log(result)
-    const decodedText = result.map(c => String.fromCharCode(c)).join('')
+    assert(result instanceof Uint8Array, 'result was not Uint8Array')
+    const decodedText = Buffer.from(result).toString()
     console.log(decodedText)
-    expect(result, [ 104, 101, 108, 108, 111 ])
+    assert(Buffer.from([ 104, 101, 108, 108, 111 ]).equals(result))
     expect(decodedText, 'hello')
   })
 


### PR DESCRIPTION
See the commit messages for full change list, but basically

 - Use typed arrays for output (breaking change)
 - Allow typed arrays as input for `GArray` / `GByteArray`
 - Validate fixed array size & element size, and fix some typos

We still need a memcpy, but transferring large data buffers should be much faster now.