### PR TITLE
fix(value): say that we can convert number to g(u)int64

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -1311,6 +1311,10 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_ULONG (gvalue)) {
         return value->IsNumber();
+    } else if (G_VALUE_HOLDS_INT64 (gvalue)) {
+        return value->IsNumber();
+    } else if (G_VALUE_HOLDS_UINT64 (gvalue)) {
+        return value->IsNumber();
     } else if (G_VALUE_HOLDS_FLOAT (gvalue)) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_DOUBLE (gvalue)) {


### PR DESCRIPTION
We already has support for it in V8ToGValue() and vice versa, so it's a
bug that CanConvertV8ToGValue() says that we cannot.