### PR TITLE
binding.gyp: ensure cflags from pkg-config is properly expanded as list

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -40,7 +40,9 @@
                 "<!(node -e \"require('nan')\")"
             ],
             "cflags": [
-                "<!@(pkg-config --cflags gobject-introspection-1.0 cairo) -Wall -g",
+                "<!@(pkg-config --cflags gobject-introspection-1.0 cairo)",
+                "-Wall",
+                "-g",
             ],
             "ldflags": [
                 "-Wl,-no-as-needed",


### PR DESCRIPTION
The flags from pkg-config got quoted together in compile_commands.json with
the previous config, and CLion failed to recognize include directory
specified in such ways. A slight modification to the gyp file seems to fix
this.