### PR TITLE
Fix macOS builds

### DIFF
--- a/src/gi.cc
+++ b/src/gi.cc
@@ -1,4 +1,4 @@
-#include <gobject-introspection-1.0/girepository.h>
+#include <girepository.h>
 #include <node.h>
 #include <nan.h>
 


### PR DESCRIPTION
Currently, the `gi.cc` file imports the `girepository.h` in a way that is inconsistent with the rest of the codebase, prefixed with a `gobject-introspection-1.0/`. This has also been breaking builds on my M1 Mac running Catalina, when installing node-gtk on Node 18. I've tested builds on both Fedora and macOS, and it seems to work perfectly.