### PR TITLE
tests: explicitly require libsoup 2.x

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -12,7 +12,7 @@ if [[ $(uname -s) == 'Darwin' ]]; then
         gtk+3 \
         gobject-introspection \
         glib \
-        libsoup \
+        libsoup@2 \
         cairo \
         gstreamer \
         gst-plugins-base \

--- a/tests/object__initialization.js
+++ b/tests/object__initialization.js
@@ -5,7 +5,7 @@
 
 const gi = require('../lib/')
 const Gtk = gi.require('Gtk', '3.0')
-const Soup = gi.require('Soup')
+const Soup = gi.require('Soup', '2.4')
 const { describe, it, mustThrow, expect, assert } = require('./__common__.js')
 
 Gtk.init()


### PR DESCRIPTION
As if libsoup3 is installed together with libsoup2, libsoup3 is selected
which makes test fails.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>