### PR TITLE
Return back interval timer

### DIFF
--- a/lib/overrides/Gtk-3.0.js
+++ b/lib/overrides/Gtk-3.0.js
@@ -32,6 +32,14 @@ exports.apply = (Gtk) => {
         process._tickCallback()
 
         const loopStack = internal.GetLoopStack()
+
+        /*
+         * To keep the nodejs event loop alive, we need to have something running.
+         */
+        if (placeholderIntervalID === undefined) {
+          placeholderIntervalID = setInterval(() => { /* noop */ }, 60 * 60 * 1000)
+        }
+
         loopStack.push(originalQuit)
 
         originalMain()


### PR DESCRIPTION
Return back code introduced in https://github.com/romgrk/node-gtk/commit/4ffe627ccb9fdf08743883ce5271c5be24597c3d and
the most probably lost during refactoring done in https://github.com/romgrk/node-gtk/commit/c64ff5b2c355636d985ee23e345bbb7a5d05b53f and considering that the code below is still there

```
if (Gtk.mainLevel() === 0) {
          placeholderIntervalID = clearInterval(placeholderIntervalID)
        }
```

Unfortunately, I don't have a simple example, but this change does fix some UI freezes.