### PR TITLE
fix(examples): pass string into editor, not buffer

### DIFF
--- a/examples/editor.js
+++ b/examples/editor.js
@@ -74,7 +74,7 @@ win.add(grid);
 
 function loadFile(filename) {
     try {
-        const content = Fs.readFileSync(filename);
+        const content = Fs.readFileSync(filename, 'utf8');
         const lang = langManager.guessLanguage(filename, null)
             || langManager.guessLanguage('file.js', null);
         label.setText(filename);


### PR DESCRIPTION
Code originally attempts to pass a Buffer into the editor contents, which fails with the following error:

```
TypeError: Cannot convert value "[object Uint8Array]" to type gchararray
    at GtkSourceBuffer.text (/home/sven/projects/_3rdparty/node-gtk/lib/bootstrap.js:194:21)
    at loadFile (/home/sven/projects/_3rdparty/node-gtk/examples/editor.js:83:21)
    at Object.<anonymous> (/home/sven/projects/_3rdparty/node-gtk/examples/editor.js:213:1)
    at Module._compile (node:internal/modules/cjs/loader:1155:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32)
    at Function.Module._load (node:internal/modules/cjs/loader:868:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47
```

Seems that the editor contents are actually expected to be a string, so this decodes it as a (UTF8) string instead. Quick test seemed to work.