### PR TITLE
fix(examples): allow propagation on key event

### DIFF
--- a/examples/entry.js
+++ b/examples/entry.js
@@ -34,6 +34,7 @@ const entry = new Gtk.Entry()
 entry.on('key-press-event', (event) => {
   console.log(event)
   console.log(event.string)
+  return false
 })
 
 


### PR DESCRIPTION
Seems that it's actually *required* to return a boolean value from at least this event handler (I assume the same is true for others). Otherwise, it produces the following error:

```
TypeError: Cannot convert value "undefined" to type gboolean in signal "key-press-event"
    at Object.main (/home/sven/projects/_3rdparty/node-gtk/lib/overrides/Gtk-3.0.js:45:9)
    at Function.<anonymous> (/home/sven/projects/_3rdparty/node-gtk/examples/entry.js:44:7)
    at Object.<anonymous> (/home/sven/projects/_3rdparty/node-gtk/examples/entry.js:50:8)
    at Module._compile (node:internal/modules/cjs/loader:1155:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32)
    at Function.Module._load (node:internal/modules/cjs/loader:868:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47
```