### PR TITLE
ci: remove node 14

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,6 @@ jobs:
         node:
           - 18
           - 16
-          - 14
     defaults:
       run:
         shell: msys2 {0}
@@ -62,7 +61,6 @@ jobs:
         node:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,11 @@
 name: main
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   build-windows:
     name: windows - nodejs ${{ matrix.node }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Node-Gtk is a [gobject-introspection](https://gi.readthedocs.io/en/latest) libra
 use any introspected library, such as Gtk+, usable.  It is similar in essence to [GJS](https://wiki.gnome.org/action/show/Projects/Gjs) or [PyGObject](https://pygobject.readthedocs.io). Please note this project is currently in a _beta_ state and is being developed. Any contributors willing to help
 will be welcomed.
 
-Supported Node.js versions: **14**, **16**, **18** (other versions should work but are untested)<br>
+Supported Node.js versions: **16**, **18** (other versions should work but are untested)<br>
 Pre-built binaries available for: **Linux**, **macOS** (all supported versions except 18)
 
 ### Table of contents


### PR DESCRIPTION
To speedup CI & cleanup unsupported versions.

Followup of #350 