### PR TITLE
Build binaries on Ubuntu 20 to support GLIBCXX_3.4.28

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-20.04
           - macos-latest
         node:
           - 18


### PR DESCRIPTION
Fixes #337.