### PR TITLE
Fix double free in GError type handling

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,6 @@ jobs:
         run: |
           npx mocha                                 \
                     --skip=callback                 \
-                    --skip=error                    \
                     --skip=union__fields            \
                     tests/__run__.js
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,13 +44,11 @@ function npm_test() {
         export GST_PLUGIN_SYSTEM_PATH=$(brew --prefix gstreamer)/lib/gstreamer-1.0;
         npx mocha                                 \
                   --skip=callback                 \
-                  --skip=error                    \
                   --skip=union__fields            \
                   tests/__run__.js
     else
         xvfb-run -a npm test --                   \
                   --skip=callback                 \
-                  --skip=error                    \
                   --skip=union__fields;
     fi;
 }

--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -425,9 +425,9 @@ Local<Value> WrapperFromBoxed(GIBaseInfo *info, void *data, ResourceOwnership ow
 
     Local<Function> constructor = MakeBoxedClass (info);
 
-    Local<Value> boxed_external = Nan::New<External> (data);
-    Local<Value> must_copy_value = Nan::New<v8::Int32> ((int32_t) ownership);
-    Local<Value> args[] = { boxed_external, must_copy_value };
+    Local<Value> jsBoxed = Nan::New<External> (data);
+    Local<Value> jsOwnership = Nan::New<v8::Int32> ((int32_t) ownership);
+    Local<Value> args[] = { jsBoxed, jsOwnership };
 
     MaybeLocal<Object> instance = Nan::NewInstance(constructor, 2, args);
 

--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -174,7 +174,7 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
 
     if (info[0]->IsExternal ()) {
         /* The External case. This is how WrapperFromBoxed is called. */
-        ResourceOwnership ownership = (ResourceOwnership) Nan::To<int32_t> (info[1]).ToChecked();
+        auto ownership = (ResourceOwnership) Nan::To<int32_t> (info[1]).ToChecked();
 
         boxed = External::Cast(*info[0])->Value();
 

--- a/src/boxed.h
+++ b/src/boxed.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "value.h"
 #include <nan.h>
 #include <node.h>
 #include <girepository.h>
@@ -30,7 +31,7 @@ public:
 
 Local<Function>         MakeBoxedClass   (GIBaseInfo *info);
 Local<FunctionTemplate> GetBoxedTemplate (GIBaseInfo *info, GType gtype);
-Local<Value>            WrapperFromBoxed (GIBaseInfo *info, void *data, bool mustCopy = false);
+Local<Value>            WrapperFromBoxed (GIBaseInfo *info, void *data, ResourceOwnership ownership = kNone);
 void *                  PointerFromWrapper (Local<Value>);
 
 };

--- a/src/callback.cc
+++ b/src/callback.cc
@@ -117,14 +117,14 @@ void Callback::Execute (GIArgument *result, GIArgument **args, Callback *callbac
 
         bool isOutArgument = g_arg_info_get_direction(&arg_info) == GI_DIRECTION_OUT;
         bool isPrimitive = Type::IsPrimitive(&arg_type);
-        bool mustCopy = isOutArgument ? false : true;
+        ResourceOwnership ownership = isOutArgument ? kNone : kCopy;
 
         if (isPrimitive && isOutArgument) {
             n_return_values += 1;
             primitive_out_arguments_mask |= 1 << i;
             js_args[i] = Nan::Null();
         } else {
-            js_args[i] = GIArgumentToV8 (&arg_type, args[i + args_offset], -1, mustCopy);
+            js_args[i] = GIArgumentToV8 (&arg_type, args[i + args_offset], -1, ownership);
         }
     }
 

--- a/src/function.cc
+++ b/src/function.cc
@@ -576,8 +576,6 @@ Local<Value> FunctionInfo::JsReturnValue (
                             else \
                                 jsReturnValue = (value);
 
-#define RESOURCE_OWNERSHIP_FROM_TRANSFER(transfer)  (transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone)
-
     int return_length_i = g_type_info_get_array_length(return_type);
 
     if (!ShouldSkipReturn(info, return_type)) {
@@ -602,7 +600,7 @@ Local<Value> FunctionInfo::JsReturnValue (
         ADD_RETURN (isReturningSelf ? self :
             GIArgumentToV8 (
                 return_type, return_value, length,
-                RESOURCE_OWNERSHIP_FROM_TRANSFER(return_transfer)))
+                return_transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone))
     }
 
     for (int i = 0; i < n_callable_args; i++) {
@@ -642,7 +640,7 @@ Local<Value> FunctionInfo::JsReturnValue (
 
             } else if (param.type == ParameterType::kNORMAL) {
                 GITransfer transfer = g_arg_info_get_ownership_transfer(&arg_info);
-                ResourceOwnership ownership = RESOURCE_OWNERSHIP_FROM_TRANSFER(transfer);
+                ResourceOwnership ownership = transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone;
 
                 if (IsPointerType(&arg_type) && g_arg_info_is_caller_allocates(&arg_info)) {
                     void *pointer = &arg_value.v_pointer;
@@ -654,8 +652,6 @@ Local<Value> FunctionInfo::JsReturnValue (
             }
         }
     }
-
-#undef RESOURCE_OWNERSHIP_FROM_TRANSFER
 
 #undef ADD_RETURN
 

--- a/src/function.h
+++ b/src/function.h
@@ -47,8 +47,7 @@ struct FunctionInfo {
 
     bool Init();
     bool TypeCheck (const Nan::FunctionCallbackInfo<Value> &info);
-    Local<Value> GetReturnValue (Local<Value> self, GITypeInfo* return_type, GIArgument* return_value, GIArgument* callable_arg_values);
-    void FreeReturnValue (GIArgument *return_value);
+    Local<Value> JsReturnValue (Local<Value> self, GITypeInfo* return_type, GIArgument* return_value, GIArgument* callable_arg_values, GITransfer return_transfer);
 };
 
 bool IsDestroyNotify (GIBaseInfo *info);

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -283,7 +283,7 @@ NAN_METHOD(StructFieldGetter) {
     }
 
     GIArgument value;
-    bool mustCopy = true;
+    GNodeJS::ResourceOwnership ownership = GNodeJS::kCopy;
     BaseInfo typeInfo = g_field_info_get_type(*fieldInfo);
 
     if (!g_field_info_get_field(*fieldInfo, boxed, &value)) {
@@ -300,13 +300,13 @@ NAN_METHOD(StructFieldGetter) {
         // auto offset = g_field_info_get_offset(*fieldInfo);
         // auto fieldPtr = G_STRUCT_MEMBER_P(boxed, offset);
         // value.v_pointer = fieldPtr;
-        // mustCopy = false;
+        // ownership = kNone;
 
         Nan::ThrowError("Converting non-primitive fields is not allowed");
         return;
     }
 
-    RETURN(GNodeJS::GIArgumentToV8(*typeInfo, &value, -1, mustCopy));
+    RETURN(GNodeJS::GIArgumentToV8(*typeInfo, &value, -1, ownership));
 }
 
 NAN_METHOD(StartLoop) {

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -72,7 +72,7 @@ static GObject* CreateGObjectFromObject(GType gtype, Local<Value> object) {
 
         g_value_init(&values[index], value_spec->value_type);
 
-        if (!V8ToGValue(&values[index], value, true)) {
+        if (!V8ToGValue(&values[index], value, kCopy)) {
             // V8ToGValue throws the error
             goto out;
         }
@@ -477,9 +477,9 @@ NAN_METHOD(SignalEmit) {
         g_value_init(gvalue, signal_query.param_types[i] & ~G_SIGNAL_TYPE_STATIC_SCOPE);
 
         if ((signal_query.param_types[i] & G_SIGNAL_TYPE_STATIC_SCOPE) != 0)
-            failed = !V8ToGValue(gvalue, info[i + 1], false); // no-copy
+            failed = !V8ToGValue(gvalue, info[i + 1], kNone); // no-copy
         else
-            failed = !V8ToGValue(gvalue, info[i + 1], true); // copy
+            failed = !V8ToGValue(gvalue, info[i + 1], kCopy); // copy
 
         if (failed)
             break;
@@ -693,7 +693,7 @@ MaybeLocal<Value> GetGObjectProperty(GObject * gobject, const char *prop_name) {
     g_value_init (&value, G_PARAM_SPEC_VALUE_TYPE (pspec));
     g_object_get_property (gobject, prop_name, &value);
 
-    auto ret = GNodeJS::GValueToV8(&value, true);
+    auto ret = GNodeJS::GValueToV8(&value, kCopy);
 
     g_value_unset(&value);
 
@@ -712,7 +712,7 @@ MaybeLocal<v8::Boolean> SetGObjectProperty(GObject * gobject, const char *prop_n
     GValue gvalue = G_VALUE_INIT;
     g_value_init(&gvalue, G_PARAM_SPEC_VALUE_TYPE (pspec));
 
-    if (GNodeJS::V8ToGValue (&gvalue, value, true)) {
+    if (GNodeJS::V8ToGValue (&gvalue, value, kCopy)) {
         g_object_set_property (gobject, prop_name, &gvalue);
         ret = Nan::True();
     } else {

--- a/src/modules/system.cc
+++ b/src/modules/system.cc
@@ -65,8 +65,8 @@ NAN_METHOD(ConvertGValue) {
         return;
     }
     void *ptr = obj->GetAlignedPointerFromInternalField (0);
-    bool mustCopy = true;
-    RETURN(GValueToV8(reinterpret_cast<GValue *>(ptr), mustCopy));
+    ResourceOwnership ownership = kCopy;
+    RETURN(GValueToV8(reinterpret_cast<GValue *>(ptr), ownership));
 }
 
 NAN_METHOD(GetMemoryContent) {

--- a/src/value.cc
+++ b/src/value.cc
@@ -36,7 +36,7 @@ static void HashPointerToGIArgument (GIArgument *arg, GITypeInfo *type_info);
 static bool IsUint8Array (GITypeInfo *type_info);
 
 
-Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length, bool mustCopy) {
+Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length, ResourceOwnership ownership) {
     GITypeTag type_tag = g_type_info_get_tag (type_info);
 
     switch (type_tag) {
@@ -128,7 +128,7 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
             case GI_INFO_TYPE_BOXED:
             case GI_INFO_TYPE_STRUCT:
             case GI_INFO_TYPE_UNION:
-                value = WrapperFromBoxed (interface_info, arg->v_pointer, mustCopy);
+                value = WrapperFromBoxed (interface_info, arg->v_pointer, ownership);
                 break;
             case GI_INFO_TYPE_ENUM:
                 value = New<Number>(arg->v_int);
@@ -233,8 +233,8 @@ Local<Value> GHashToV8 (GITypeInfo *type_info, GHashTable *hash_table) {
 }
 
 Local<Value> GErrorToV8 (GITypeInfo *type_info, GError *err) {
-    auto err_info = g_irepository_find_by_name(NULL, "GLib", "Error");
-    auto obj = WrapperFromBoxed (err_info, err, true);
+    auto err_info = g_irepository_find_by_gtype(NULL, g_error_get_type());
+    auto obj = WrapperFromBoxed (err_info, err);
     return obj;
 }
 
@@ -1185,6 +1185,9 @@ void FreeGIArgument(GITypeInfo *type_info, GIArgument *arg, GITransfer transfer,
             case GI_INFO_TYPE_UNION:
             {
                 // handled by gobject.cc/boxed.cc
+
+                // no free since we took the ptr directly from box
+                // see V8ToGIArgument
                 break;
             }
             case GI_INFO_TYPE_ENUM:
@@ -1241,7 +1244,8 @@ void FreeGIArgument(GITypeInfo *type_info, GIArgument *arg, GITransfer transfer,
 
     case GI_TYPE_TAG_ERROR:
     {
-        g_error_free((GError *)arg->v_pointer);
+        // no g_error_free since we took the ptr directly from box
+        // see V8ToGIArgument and GErrorToV8
         break;
     }
 
@@ -1424,7 +1428,7 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
             G_VALUE_TYPE_NAME (gvalue));
 }
 
-bool V8ToGValue(GValue *gvalue, Local<Value> value, bool mustCopy) {
+bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership) {
     if (!CanConvertV8ToGValue(gvalue, value)) {
         auto maybeDetailString = Nan::ToDetailString(value);
         Nan::Utf8String utf8String(
@@ -1487,7 +1491,7 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, bool mustCopy) {
             Throw::CannotConvertGType("boxed", G_VALUE_TYPE (gvalue));
             return false;
         }
-        if (mustCopy)
+        if (ownership == kCopy)
             g_value_set_boxed (gvalue, PointerFromWrapper(value));
         else
             g_value_set_static_boxed (gvalue, PointerFromWrapper(value));
@@ -1508,7 +1512,7 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, bool mustCopy) {
     return true;
 }
 
-Local<Value> GValueToV8(const GValue *gvalue, bool mustCopy) {
+Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
     // by-value types
     if (G_VALUE_HOLDS_BOOLEAN (gvalue)) {
         return New<v8::Boolean>(g_value_get_boolean (gvalue));
@@ -1555,7 +1559,7 @@ Local<Value> GValueToV8(const GValue *gvalue, bool mustCopy) {
             Throw::InvalidGType(gtype);
             return Nan::Null(); // FIXME(return a MaybeLocal instead?)
         }
-        Local<Value> obj = WrapperFromBoxed(info, g_value_get_boxed(gvalue), mustCopy);
+        Local<Value> obj = WrapperFromBoxed(info, g_value_get_boxed(gvalue), ownership);
         g_base_info_unref(info);
         return obj;
     } else if (G_VALUE_HOLDS_PARAM (gvalue)) {

--- a/src/value.h
+++ b/src/value.h
@@ -21,11 +21,11 @@ Local<Value> GListToV8  (GITypeInfo *info, GList  *glist);
 Local<Value> GSListToV8 (GITypeInfo *info, GSList *glist);
 Local<Value> GHashToV8 (GITypeInfo *info, GHashTable *hash);
 Local<Value> ArrayToV8  (GITypeInfo *info, gpointer data, long length = -1);
-Local<Value> GErrorToV8 (GITypeInfo *type_info, GError *err);
+Local<Value> GErrorToV8 (GITypeInfo *type_info, GError *err, ResourceOwnership ownership = kNone);
 Local<Value> GIArgumentToV8 (GITypeInfo *type_info, GIArgument *argument, long length = -1, ResourceOwnership ownership = kNone);
 long         GIArgumentToLength(GITypeInfo *type_info, GIArgument *arg, bool is_pointer);
 
-bool         V8ToGIArgument (GITypeInfo *type_info, GIArgument *argument, Local<Value> value);
+bool         V8ToGIArgumentInterface (GIBaseInfo *gi_info, GIArgument *argument, Local<Value> value);
 bool         V8ToGIArgument (GITypeInfo *type_info, GIArgument *argument, Local<Value> value, bool may_be_null);
 bool         V8ToOutGIArgument(GITypeInfo *type_info, GIArgument *arg, Local<Value> value, bool may_be_null);
 void         FreeGIArgument (GITypeInfo *type_info, GIArgument *argument, GITransfer transfer = GI_TRANSFER_EVERYTHING, GIDirection direction = GI_DIRECTION_OUT);

--- a/src/value.h
+++ b/src/value.h
@@ -11,12 +11,18 @@ using v8::Local;
 
 namespace GNodeJS {
 
+enum ResourceOwnership {
+    kNone,
+    kCopy,
+    kTransfer
+};
+
 Local<Value> GListToV8  (GITypeInfo *info, GList  *glist);
 Local<Value> GSListToV8 (GITypeInfo *info, GSList *glist);
 Local<Value> GHashToV8 (GITypeInfo *info, GHashTable *hash);
 Local<Value> ArrayToV8  (GITypeInfo *info, gpointer data, long length = -1);
 Local<Value> GErrorToV8 (GITypeInfo *type_info, GError *err);
-Local<Value> GIArgumentToV8 (GITypeInfo *type_info, GIArgument *argument, long length = -1, bool mustCopy = false);
+Local<Value> GIArgumentToV8 (GITypeInfo *type_info, GIArgument *argument, long length = -1, ResourceOwnership ownership = kNone);
 long         GIArgumentToLength(GITypeInfo *type_info, GIArgument *arg, bool is_pointer);
 
 bool         V8ToGIArgument (GITypeInfo *type_info, GIArgument *argument, Local<Value> value);
@@ -26,8 +32,8 @@ void         FreeGIArgument (GITypeInfo *type_info, GIArgument *argument, GITran
 void         FreeGIArgumentArray (GITypeInfo *type_info, GIArgument *arg, GITransfer transfer = GI_TRANSFER_EVERYTHING, GIDirection direction = GI_DIRECTION_OUT, long length = -1);
 bool         CanConvertV8ToGIArgument (GITypeInfo *type_info, Local<Value> value, bool may_be_null);
 
-bool         V8ToGValue(GValue *gvalue, Local<Value> value, bool mustCopy = false);
-Local<Value> GValueToV8(const GValue *gvalue, bool mustCopy = false);
+bool         V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership = kNone);
+Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership = kNone);
 bool         CanConvertV8ToGValue(GValue *gvalue, Local<Value> value);
 
 bool         ValueHasInternalField  (Local<Value> value);


### PR DESCRIPTION
There may be similar issue in other places, or memory leaks for other types, but at least for GError it should work as expected.

CI for error.js is re-enabled as well.