### PR TITLE
Fixes a segfault with callbacks seen on Ubuntu 26

### DIFF
--- a/src/callback.cc
+++ b/src/callback.cc
@@ -34,8 +34,10 @@ Callback::Callback(Local<Function> fn, GICallableInfo* callback_info, GIScopeTyp
     info = g_base_info_ref (callback_info);
     #ifdef GI_AVAILABLE_IN_1_72
     closure = g_callable_info_create_closure(info, &cif, Callback::Call, this);
+    native_address = g_callable_info_get_closure_native_address(info, closure);
     #else
     closure = g_callable_info_prepare_closure(info, &cif, Callback::Call, this);
+    native_address = (gpointer) closure;
     #endif
     scope_type = scope_type_;
 }

--- a/src/callback.h
+++ b/src/callback.h
@@ -16,6 +16,7 @@ namespace GNodeJS {
 struct Callback {
     ffi_cif cif;
     ffi_closure *closure;
+    gpointer native_address; /* callable trampoline; may differ from closure on libffi 3.4+ */
     Nan::Persistent<Function> persistent;
     GICallableInfo *info;
     GIScopeType scope_type;

--- a/src/function.cc
+++ b/src/function.cc
@@ -388,16 +388,16 @@ Local<Value> FunctionCall (
         }
         else if (param.type == ParameterType::kCALLBACK) {
             Callback *callback;
-            ffi_closure *closure;
+            gpointer callable; /* executable trampoline address */
 
             if (info[in_arg]->IsNullOrUndefined()) {
-                closure  = nullptr;
+                callable  = nullptr;
                 callback = nullptr;
             } else {
                 GICallableInfo *callback_info = g_type_info_get_interface (&type_info);
                 GIScopeType scope_type = g_arg_info_get_scope(&arg_info);
                 callback = new Callback(info[in_arg].As<Function>(), callback_info, scope_type);
-                closure = callback->closure;
+                callable = callback->native_address;
                 g_base_info_unref (callback_info);
             }
 
@@ -414,7 +414,7 @@ Local<Value> FunctionCall (
                 callable_arg_values[closure_i].v_pointer = callback;
             }
 
-            callable_arg_values[i].v_pointer = closure;
+            callable_arg_values[i].v_pointer = callable;
             func->call_parameters[i].data.v_pointer = callback;
         }
 

--- a/tests/callback.js
+++ b/tests/callback.js
@@ -4,7 +4,7 @@ const Gio = gi.require('Gio', '2.0')
 const Gst = gi.require('Gst', '1.0')
 const common = require('./__common__.js')
 
-Gst.init()
+Gst.init([])
 gi.startLoop()
 
 common.describe('callback value is set', () => {

--- a/tests/enum.js
+++ b/tests/enum.js
@@ -12,7 +12,7 @@ const Gst = gi.require('Gst')
 const common = require('./__common__.js')
 
 Gtk.init()
-Gst.init()
+Gst.init([])
 
 common.describe('enum', () => {
   common.it('are defined', () => {

--- a/tests/error.js
+++ b/tests/error.js
@@ -8,7 +8,7 @@ const GLib = gi.require('GLib', '2.0')
 const Gst = gi.require('Gst', '1.0')
 const { describe, it, assert, expect } = require('./__common__.js')
 
-Gst.init()
+Gst.init([])
 
 const QUARK_STRING = 'example'
 const CUSTOM_QUARK = GLib.quarkFromString(QUARK_STRING)

--- a/tests/function_call.js
+++ b/tests/function_call.js
@@ -9,7 +9,7 @@ const Gst = gi.require('Gst', '1.0')
 const { describe, it, mustThrow, expect } = require('./__common__.js')
 
 Gtk.init()
-Gst.init();
+Gst.init([]);
 
 describe('function arguments', () => {
   it('works', () => {

--- a/tests/object__non-introspected.js
+++ b/tests/object__non-introspected.js
@@ -4,7 +4,7 @@ const GObject = gi.require('GObject', '2.0')
 const { assert, describe, expect, it } = require('./__common__.js')
 
 gi.startLoop()
-Gst.init()
+Gst.init([])
 
 describe('create introspected objected', () => {
   const bin = new Gst.Bin('name')

--- a/tests/regressions.js
+++ b/tests/regressions.js
@@ -11,7 +11,7 @@ const Soup = gi.require('Soup')
 const Cairo = gi.require('cairo', '1.0')
 const { describe, expect } = require('./__common__.js')
 
-Gst.init()
+Gst.init([])
 Gtk.init()
 gi.startLoop()
 

--- a/tests/signal__non-introspected.js
+++ b/tests/signal__non-introspected.js
@@ -8,7 +8,7 @@ const Gst = gi.require('Gst', '1.0')
 const { describe, it, mustThrow, assert, expect } = require('./__common__.js')
 
 gi.startLoop()
-Gst.init()
+Gst.init([])
 
 describe('signal handlers are available for non-introspected objects', async () => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #390.

Disclaimer: I used Claude to debug this. Claude failed twice but then got on the right path when I ran gdb and pin-pointed the line in function.cc where it happens. It then produced a patch that was much to large, including all its failed attempts before. Those changes may still have merit, but they weren't essential for fixing this, so I narrowed it down to what appears the essential change.

Tested with both reported cases, which now work.

PS: also updated the test cases to use the newly required parameter for `Gst.init`.