### PR TITLE
fix: nine correctness/safety bugs from full-source review

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -82,11 +82,26 @@ function extendBaseClass(BaseClass) {
   }
 
   BaseClass.prototype.once = function once(event, callback, after) {
+    defineListeners(this)
+
+    if (!this._listeners.has(event))
+      this._listeners.set(event, new WeakMap())
+
+    const fnMap = this._listeners.get(event)
+
     const newCallback = (...args) => {
-      callback(...args)
-      this.off(event, newCallback)
+      this.off(event, callback)
+      return callback(...args)
     }
-    this.on(event, newCallback, after)
+
+    const handlerID = this.connect(event, newCallback, after)
+    if (handlerID === 0) {
+      throw new Error(`Could not connect to signal ${event}`)
+    }
+    // Key the listener map by the user's original callback so that it can be
+    // cancelled with off(event, callback), even though the connected handler
+    // is the wrapper.
+    fnMap.set(callback, handlerID)
     return this
   }
 

--- a/lib/overrides/Gtk-4.0.js
+++ b/lib/overrides/Gtk-4.0.js
@@ -112,7 +112,8 @@ exports.apply = (Gtk) => {
    */
   Gtk.FileChooserDialog.prototype.getFile = function getFile() {
     const file = originalGetFile.call(this)
-    file.__proto__= Gio.File.prototype
+    if (file)
+      file.__proto__= Gio.File.prototype
     return file
   }
 
@@ -122,7 +123,8 @@ exports.apply = (Gtk) => {
    */
   Gtk.FileChooserWidget.prototype.getFile = function getFile() {
     const file = originalGetFile.call(this)
-    file.__proto__= Gio.File.prototype
+    if (file)
+      file.__proto__= Gio.File.prototype
     return file
   }
 }

--- a/lib/register-class.js
+++ b/lib/register-class.js
@@ -119,7 +119,7 @@ function findVFuncOnParents(info, name) {
 function findVFuncOnInterfaces(gtype, name) {
   const interfaces = GObject.typeInterfaces(gtype);
 
-  for (i = 0; i < interfaces.length; i++) {
+  for (let i = 0; i < interfaces.length; i++) {
     const interfaceInfo = findInfoByGtype(interfaces[i])
 
     /* The interface doesn't have to exist, it could be private

--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -162,7 +162,7 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
         return;
     }
 
-    GIFunctionInfo* constructorInfo = NULL;
+    int n_constructor_args = -1;
 
     void *boxed = NULL;
     unsigned long size = 0;
@@ -200,6 +200,8 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
         GIFunctionInfo* constructorInfo = FindBoxedConstructor(gi_info, gtype);
 
         if (constructorInfo != NULL) {
+
+            n_constructor_args = g_callable_info_get_n_args(constructorInfo);
 
             FunctionInfo func(constructorInfo);
             GIArgument return_value;
@@ -250,7 +252,7 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
 
     SET_OBJECT_GTYPE (self, gtype);
 
-    if (constructorInfo == NULL || g_callable_info_get_n_args(constructorInfo) == 0)
+    if (n_constructor_args <= 0)
         InitBoxedFromObject(self, info[0]);
 }
 

--- a/src/callback.cc
+++ b/src/callback.cc
@@ -171,6 +171,7 @@ void Callback::Execute (GIArgument *result, GIArgument **args, Callback *callbac
             if (jsReturnArray->Length() != n_js_return_values) {
                 Throw::Error("Virtual function must return %u arguments but returned %u",
                         n_js_return_values, jsReturnArray->Length());
+                goto out;
             }
 
             if (hasVoidReturn)
@@ -194,6 +195,7 @@ void Callback::Execute (GIArgument *result, GIArgument **args, Callback *callbac
 
                 if (!success) {
                     Throw::InvalidReturnValue (&return_type_info, jsReturnValue);
+                    goto out;
                 }
             }
         }

--- a/src/function.cc
+++ b/src/function.cc
@@ -208,14 +208,14 @@ bool FunctionInfo::Init() {
                     if (closure_i >= 0 && closure_i < n_callable_args)
                         call_parameters[closure_i].type = ParameterType::kSKIP;
 
-                    if (destroy_i < i) {
+                    if (destroy_i >= 0 && destroy_i < i) {
                         if (IsDirectionIn(call_parameters[destroy_i].direction))
                             n_in_args--;
                         if (IsDirectionOut(call_parameters[destroy_i].direction))
                             n_out_args--;
                     }
 
-                    if (closure_i < i) {
+                    if (closure_i >= 0 && closure_i < i) {
                         if (IsDirectionIn(call_parameters[closure_i].direction))
                             n_in_args--;
                         if (IsDirectionOut(call_parameters[closure_i].direction))

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -333,8 +333,7 @@ static void StoreVFunc(GType gtype, Callback *callback) {
 static void DestroyVFuncs(GType gtype) {
     /* Destroy vfunc list, if any */
     GSList *list = (GSList *) g_type_get_qdata (gtype, GNodeJS::vfuncs_quark());
-    GSList *item = list;
-    while ((item = g_slist_next (item)) != NULL) {
+    for (GSList *item = list; item != NULL; item = item->next) {
         auto callback = (Callback *) item->data;
         delete callback;
     }

--- a/src/type.cc
+++ b/src/type.cc
@@ -15,11 +15,12 @@ char *GetInfoName (GIBaseInfo* info) {
 
     char* name = g_strdup (info_name);
 
-    GIBaseInfo *parent;
-    while ((parent = g_base_info_get_container (info)) != NULL) {
+    GIBaseInfo *parent = g_base_info_get_container (info);
+    while (parent != NULL) {
         char *new_name = g_strconcat (g_base_info_get_name(parent), ".", name, NULL);
         g_free (name);
         name = new_name;
+        parent = g_base_info_get_container (parent);
     }
 
     char *new_name = g_strconcat (g_base_info_get_namespace(info), ".", name, NULL);

--- a/src/value.cc
+++ b/src/value.cc
@@ -1455,11 +1455,11 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership)
     } else if (G_VALUE_HOLDS_LONG (gvalue)) {
         g_value_set_long (gvalue, Nan::To<int64_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_ULONG (gvalue)) {
-        g_value_set_ulong (gvalue, Nan::To<uint32_t> (value).ToChecked());
+        g_value_set_ulong (gvalue, Nan::To<int64_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_INT64 (gvalue)) {
         g_value_set_int64 (gvalue, Nan::To<int64_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_UINT64 (gvalue)) {
-        g_value_set_uint64 (gvalue, Nan::To<uint32_t> (value).ToChecked());
+        g_value_set_uint64 (gvalue, Nan::To<int64_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_FLOAT (gvalue)) {
         g_value_set_float (gvalue, Nan::To<double> (value).ToChecked());
     } else if (G_VALUE_HOLDS_DOUBLE (gvalue)) {

--- a/tests/conversion__gvalue_uint64.js
+++ b/tests/conversion__gvalue_uint64.js
@@ -1,0 +1,32 @@
+/*
+ * conversion__gvalue_uint64.js
+ *
+ * Regression test: assigning a 64-bit value to a GObject property whose
+ * type is guint64 (or gulong on LP64) must not truncate it to 32 bits.
+ * This exercises V8ToGValue, which used Nan::To<uint32_t> for the
+ * UINT64/ULONG branches.
+ */
+
+const gi = require('../lib/')
+const { describe, expect, skip } = require('./__common__.js')
+
+let Gst
+try {
+  Gst = gi.require('Gst', '1.0')
+  Gst.init([])
+} catch (e) {
+  console.log('Gst not available, skipping:', e.message)
+  skip()
+}
+
+describe('GValue 64-bit property assignment', () => {
+  const queue = Gst.ElementFactory.make('queue', 'queue0')
+
+  // max-size-time is a writable guint64 property (nanoseconds).
+  // Use a value above 2^32 but still an exact JS integer (< 2^53).
+  const value = 5000000000 // 2^32 == 4294967296
+
+  queue.maxSizeTime = value
+
+  expect(queue.maxSizeTime, value)
+})

--- a/tests/overrides__gtk4_getfile.js
+++ b/tests/overrides__gtk4_getfile.js
@@ -1,0 +1,28 @@
+/*
+ * overrides__gtk4_getfile.js
+ *
+ * Regression test: Gtk4 FileChooser getFile() override must not crash when
+ * no file is selected. gtk_file_chooser_get_file() returns NULL in that
+ * case, and the override unconditionally did `file.__proto__ = ...`.
+ */
+
+const gi = require('../lib/')
+const { describe, it, expect, skip } = require('./__common__.js')
+
+let Gtk
+try {
+  Gtk = gi.require('Gtk', '4.0')
+  gi.startLoop()
+  Gtk.init()
+} catch (e) {
+  console.log('Gtk 4.0 not available, skipping:', e.message)
+  skip()
+}
+
+describe('Gtk4 FileChooser.getFile', () => {
+  it('returns null instead of throwing when nothing is selected', () => {
+    const chooser = new Gtk.FileChooserWidget({ action: Gtk.FileChooserAction.OPEN })
+    const file = chooser.getFile()
+    expect(file, null)
+  })
+})

--- a/tests/register-class__no_global_leak.js
+++ b/tests/register-class__no_global_leak.js
@@ -1,0 +1,30 @@
+/*
+ * register-class__no_global_leak.js
+ *
+ * Regression test: registering a class must not leak an implicit global.
+ * findVFuncOnInterfaces() used `for (i = 0; ...)` with an undeclared `i`,
+ * which (in non-strict module scope) created a `global.i`.
+ */
+
+const { describe, it, expect } = require('./__common__')
+
+const gi = require('..')
+const Gtk = gi.require('Gtk', '3.0'); Gtk.init([])
+
+describe('registerClass', () => {
+  it('does not leak an implicit global `i`', () => {
+    // Clear any pre-existing value so we measure only our registration.
+    delete global.i
+
+    class NoLeakWidget extends Gtk.Widget {
+      static GTypeName = 'NodeGTKNoLeakWidget'
+      // A method whose snake_case name is not a parent vfunc forces
+      // findVFuncOnInterfaces() to run.
+      someCustomMethod() {}
+    }
+
+    gi.registerClass(NoLeakWidget)
+
+    expect('i' in global, false)
+  })
+})

--- a/tests/signal__once_off.js
+++ b/tests/signal__once_off.js
@@ -1,0 +1,40 @@
+/*
+ * signal__once_off.js
+ *
+ * Regression test: a `once()` listener must be cancellable with
+ * `off(event, originalCallback)` (matching Node EventEmitter semantics).
+ * Previously `once` stored its internal wrapper as the listener map key,
+ * so `off` with the user's original callback could not find it.
+ */
+
+const gi = require('../lib/')
+const Gtk = gi.require('Gtk', '3.0')
+const { describe, it, expect } = require('./__common__.js')
+
+gi.startLoop()
+Gtk.init()
+
+describe('once', () => {
+  it('can be cancelled with off(originalCallback)', () => {
+    const button = new Gtk.Button()
+    let calls = 0
+    const cb = () => { calls++ }
+
+    button.once('clicked', cb)
+    button.off('clicked', cb)
+    button.clicked()
+
+    expect(calls, 0)
+  })
+
+  it('still fires exactly once when not cancelled', () => {
+    const button = new Gtk.Button()
+    let calls = 0
+
+    button.once('clicked', () => { calls++ })
+    button.clicked()
+    button.clicked()
+
+    expect(calls, 1)
+  })
+})


### PR DESCRIPTION
Fixes nine bugs found in a full-source review (excluding `src/modules`, which is autogenerated). Each is a self-contained commit. Where a bug is observable from JS, the commit adds a regression test (written failing-first, then fixed); the rest are memory-safety/latent fixes verified by analysis and by the existing suite staying green.

## Fixes with regression tests
- **64-bit GValue truncation** (`value.cc`) — `V8ToGValue` used `Nan::To<uint32_t>` for the `UINT64`/`ULONG` branches, silently truncating values above 2³² (gulong is 64-bit on LP64). Test assigns 5e9 to a `guint64` property and reads it back.
- **Implicit global `i`** (`register-class.js`) — `findVFuncOnInterfaces` used an undeclared loop variable, leaking `global.i` on every class registration. Test asserts no global is created.
- **`once()` can't be cancelled** (`bootstrap.js`) — `once()` stored its internal wrapper as the listener-map key, so `off(event, originalCallback)` couldn't disconnect it (and the connection leaked until fired). Now keyed by the original callback. Test covers off-cancellation and single-fire.
- **Gtk4 `getFile()` null deref** (`Gtk-4.0.js`) — `gtk_file_chooser_get_file()` returns NULL when nothing is selected, but the override did `file.__proto__ = ...` unconditionally. Test creates a chooser and calls `getFile()`.

## Fix-only (not deterministically observable from JS)
- **`GetInfoName` infinite loop** (`type.cc`) — the container-walk loop re-read the unchanging `info` instead of advancing to the parent; any info with a container would spin forever building an ever-longer string.
- **`DestroyVFuncs` vfunc leak** (`gobject.cc`) — `while ((item = g_slist_next(item)))` skipped the head node, leaking the most-recently-registered vfunc Callback and its libffi closure.
- **OOB `call_parameters[-1]` read** (`function.cc`) — `g_arg_info_get_destroy/closure` return `-1` for callbacks with no notifier; the `< i` guards lacked a `>= 0` check and dereferenced index `-1`, corrupting argument counts.
- **boxed `constructorInfo` shadowing** (`boxed.cc`) — a shadowing local made the guard always read NULL, so `InitBoxedFromObject` ran even after arg-taking constructors.
- **Missing early-out in vfunc return marshalling** (`callback.cc`) — after throwing on a return-array length mismatch, execution fell through and kept marshalling out-args past bounds with an exception already pending; added the missing `goto out`.

## Testing
- New regression tests pass; each was confirmed red against unfixed code and green after the fix.
- Full focused suite (27 tests incl. `regressions.js`, boxed/struct/union constructors, vfunc registration) stays green; native module compiles with only pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)