### PR TITLE
fix: convert JS arrays to/from GStrv properties (#175)

### DIFF
--- a/examples/widget-gallery.js
+++ b/examples/widget-gallery.js
@@ -66,14 +66,6 @@ function onActivate() {
   loop.run()
 }
 
-/* Add one or more CSS classes to a widget and return it.
- * (node-gtk can't set the array-valued `css-classes` construct property.) */
-function styled(widget, ...classes) {
-  for (const c of classes)
-    widget.addCssClass(c)
-  return widget
-}
-
 /* A scrolled, clamped vertical column — the canonical Adwaita content layout. */
 function makePage(spacing = 18) {
   const scrolled = new Gtk.ScrolledWindow({ vexpand: true })
@@ -96,7 +88,7 @@ function buildRowsPage() {
 
   const action = new Adw.ActionRow({ title: 'Action Row', subtitle: 'With a prefix icon and a suffix button' })
   action.addPrefix(new Gtk.Image({ 'icon-name': 'starred-symbolic' }))
-  action.addSuffix(styled(new Gtk.Button({ 'icon-name': 'go-next-symbolic', valign: Gtk.Align.CENTER }), 'flat'))
+  action.addSuffix(new Gtk.Button({ 'icon-name': 'go-next-symbolic', valign: Gtk.Align.CENTER, 'css-classes': ['flat'] }))
   action.setActivatableWidget(action)
   group.add(action)
 
@@ -137,8 +129,8 @@ function buildButtonsPage(toastOverlay) {
   column.append(styles)
   const styleBox = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, spacing: 8, homogeneous: true, 'margin-top': 6 })
   const regular = new Gtk.Button({ label: 'Regular' })
-  const suggested = styled(new Gtk.Button({ label: 'Suggested' }), 'suggested-action')
-  const destructive = styled(new Gtk.Button({ label: 'Destructive' }), 'destructive-action')
+  const suggested = new Gtk.Button({ label: 'Suggested', 'css-classes': ['suggested-action'] })
+  const destructive = new Gtk.Button({ label: 'Destructive', 'css-classes': ['destructive-action'] })
   for (const b of [regular, suggested, destructive]) {
     b.on('clicked', toast(`${b.getLabel()} clicked`))
     styleBox.append(b)
@@ -149,15 +141,15 @@ function buildButtonsPage(toastOverlay) {
   const shapes = new Adw.PreferencesGroup({ title: 'Shapes' })
   column.append(shapes)
   const shapeBox = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, spacing: 8, halign: Gtk.Align.CENTER, 'margin-top': 6 })
-  shapeBox.append(styled(new Gtk.Button({ label: 'Pill Button' }), 'pill', 'suggested-action'))
-  shapeBox.append(styled(new Gtk.Button({ 'icon-name': 'list-add-symbolic' }), 'circular'))
+  shapeBox.append(new Gtk.Button({ label: 'Pill Button', 'css-classes': ['pill', 'suggested-action'] }))
+  shapeBox.append(new Gtk.Button({ 'icon-name': 'list-add-symbolic', 'css-classes': ['circular'] }))
   shapes.add(shapeBox)
 
   // Linked group + a split button
   const grouped = new Adw.PreferencesGroup({ title: 'Grouped' })
   column.append(grouped)
   const groupedBox = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, spacing: 12, halign: Gtk.Align.CENTER, 'margin-top': 6 })
-  const linked = styled(new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL }), 'linked')
+  const linked = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, 'css-classes': ['linked'] })
   linked.append(new Gtk.Button({ 'icon-name': 'format-justify-left-symbolic' }))
   linked.append(new Gtk.Button({ 'icon-name': 'format-justify-center-symbolic' }))
   linked.append(new Gtk.Button({ 'icon-name': 'format-justify-right-symbolic' }))

--- a/src/value.cc
+++ b/src/value.cc
@@ -1410,6 +1410,9 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
         return value->IsString();
     } else if (G_VALUE_HOLDS_OBJECT (gvalue)) {
         return ValueIsInstanceOfGType(value, G_VALUE_TYPE (gvalue));
+    } else if (G_VALUE_HOLDS (gvalue, G_TYPE_STRV)) {
+        // GStrv is a boxed type, so this must come before G_VALUE_HOLDS_BOXED.
+        return value->IsArray();
     } else if (G_VALUE_HOLDS_BOXED (gvalue)) {
         return ValueIsInstanceOfGType(value, G_VALUE_TYPE (gvalue));
     } else if (G_VALUE_HOLDS_PARAM (gvalue)) {
@@ -1482,6 +1485,16 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership)
             return false;
         }
         g_value_set_object (gvalue, GObjectFromWrapper (value));
+    } else if (G_VALUE_HOLDS (gvalue, G_TYPE_STRV)) {
+        // GStrv is a boxed type, so this must come before G_VALUE_HOLDS_BOXED.
+        Local<Array> array = Local<Array>::Cast(TO_OBJECT (value));
+        int length = array->Length();
+        char **strv = g_new0 (char *, length + 1);
+        for (int i = 0; i < length; i++) {
+            Nan::Utf8String element (Nan::Get(array, i).ToLocalChecked());
+            strv[i] = g_strdup (*element);
+        }
+        g_value_take_boxed (gvalue, strv);
     } else if (G_VALUE_HOLDS_BOXED (gvalue)) {
         if (!ValueIsInstanceOfGType(value, G_VALUE_TYPE (gvalue))) {
             Throw::CannotConvertGType("boxed", G_VALUE_TYPE (gvalue));
@@ -1548,6 +1561,15 @@ Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
             return Nan::EmptyString();
     } else if (G_VALUE_HOLDS_OBJECT (gvalue)) {
         return WrapperFromGObject (G_OBJECT (g_value_get_object (gvalue)));
+    } else if (G_VALUE_HOLDS (gvalue, G_TYPE_STRV)) {
+        // GStrv is a boxed type, so this must come before G_VALUE_HOLDS_BOXED.
+        char **strv = (char **) g_value_get_boxed (gvalue);
+        Local<Array> array = Nan::New<Array>();
+        if (strv != NULL) {
+            for (guint i = 0; strv[i] != NULL; i++)
+                Nan::Set(array, i, New<String>(strv[i]).ToLocalChecked());
+        }
+        return array;
     } else if (G_VALUE_HOLDS_BOXED (gvalue)) {
         GType gtype = G_VALUE_TYPE (gvalue);
         GIBaseInfo *info = g_irepository_find_by_gtype(NULL, gtype);

--- a/tests/conversion__gvalue_strv.js
+++ b/tests/conversion__gvalue_strv.js
@@ -1,0 +1,39 @@
+/*
+ * conversion__gvalue_strv.js
+ *
+ * Regression test for #175 / #369: assigning a JS array to a GObject property
+ * whose type is GStrv (a NULL-terminated char**) must work. GStrv is a boxed
+ * type, so before the fix it fell into the generic G_VALUE_HOLDS_BOXED branch
+ * in value.cc and threw `Cannot convert value "[object Array]" to type GStrv`.
+ *
+ * Exercises both directions: V8ToGValue (set) and GValueToV8 (get).
+ */
+
+const gi = require('../lib/')
+const { describe, expect, skip } = require('./__common__.js')
+
+let Gtk
+try {
+  Gtk = gi.require('Gtk', '3.0')
+  Gtk.init([])
+} catch (e) {
+  console.log('Gtk not available, skipping:', e.message)
+  skip()
+}
+
+describe('GStrv property via construct property', () => {
+  // `authors` is a writable GStrv property on GtkAboutDialog (the #369 case).
+  const dialog = new Gtk.AboutDialog({ authors: ['Ada Lovelace', 'Alan Turing'] })
+  expect(dialog.authors, ['Ada Lovelace', 'Alan Turing'])
+})
+
+describe('GStrv property via setter', () => {
+  const dialog = new Gtk.AboutDialog()
+  dialog.authors = ['Grace Hopper']
+  expect(dialog.authors, ['Grace Hopper'])
+})
+
+describe('GStrv property with an empty array', () => {
+  const dialog = new Gtk.AboutDialog({ authors: [] })
+  expect(dialog.authors, [])
+})

--- a/tests/object__property.js
+++ b/tests/object__property.js
@@ -45,7 +45,7 @@ win.on('show', () => {
     // console.log('object:', win.parent)
 
     // console.log('ghash:', settings.colorHash = new GLib.HashTable(() => 0, () => false))
-    // console.log('array:', scaleBtn.icons = ['arrow1-down', 'diamond-outline-thick'])
+    console.log('strv:', scaleBtn.icons = ['arrow1-down', 'diamond-outline-thick'])
   })
 
   describe('getters', () => {
@@ -62,7 +62,7 @@ win.on('show', () => {
     console.log('object:',         isntUndefined(win.parent))
 
     console.log('ghash:',          isntUndefined(settings.colorHash))
-    // console.log('array:', isntUndefined(scaleBtn.icons))
+    console.log('strv:',           expect(scaleBtn.icons, ['arrow1-down', 'diamond-outline-thick']))
   })
 
   win.close()


### PR DESCRIPTION
## Summary

Fixes #175 (and the duplicate #369): assigning a JS array to a `GStrv`-typed GObject property threw

```
Cannot convert value "[object Array]" to type GStrv
```

`GStrv` (a NULL-terminated `char**`) is registered as a **boxed** type, so these properties fell into the generic `G_VALUE_HOLDS_BOXED` branch in `value.cc`, where `ValueIsInstanceOfGType` rejects a plain JS array. This affected common properties like GTK4's `css-classes`, `GtkAboutDialog:authors` (the #369 repro) and `GtkScaleButton:icons` (the example #175 points at).

## Changes

Special-case `G_TYPE_STRV` **before** the boxed branch in all three conversion paths in `src/value.cc`:

- **`CanConvertV8ToGValue`** — accept arrays for STRV.
- **`V8ToGValue`** (set) — build a `char**` from the array and hand ownership to the GValue via `g_value_take_boxed`.
- **`GValueToV8`** (get) — read the `char**` back into a JS array, so getters round-trip too.

## Tests

- New `tests/conversion__gvalue_strv.js` — covers construct property, setter, and empty array via `GtkAboutDialog:authors`.
- `tests/object__property.js` — enabled the previously commented-out `scaleBtn.icons` strv set/get assertions (the reproduction referenced in #175).

Verified locally: the new test and the existing `gvalue`, `object__property`, `boxed__properties`, and `conversion__gvalue_uint64` tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)