### PR TITLE
fix: marshal integer-keyed GHashTable IN without dereferencing keys (#402)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/romgrk/src/node-gtk/node_modules

--- a/src/value.cc
+++ b/src/value.cc
@@ -607,10 +607,15 @@ gpointer V8ToGHash (GITypeInfo *type_info, Local<Value> value) {
         case GI_TYPE_TAG_UINT16:
         case GI_TYPE_TAG_INT32:
         case GI_TYPE_TAG_UINT32:
-            hash_func  = g_int_hash;
-            equal_func = g_int_equal;
-            break;
         case GI_TYPE_TAG_GTYPE:
+            // The key is stored directly in the pointer via
+            // GINT_TO_POINTER/GSIZE_TO_POINTER (see GIArgumentToHashPointer),
+            // matching the GObject-introspection convention. g_int_hash and
+            // g_int64_hash dereference their argument as a pointer-to-integer,
+            // so they crash on these packed values — use g_direct_* instead.
+            hash_func  = g_direct_hash;
+            equal_func = g_direct_equal;
+            break;
         case GI_TYPE_TAG_INT64:
         case GI_TYPE_TAG_UINT64:
             hash_func  = g_int64_hash;
@@ -665,7 +670,9 @@ gpointer V8ToGHash (GITypeInfo *type_info, Local<Value> value) {
             goto item_error;
         }
 
-        g_hash_table_insert (hash_table, key_arg.v_pointer, GIArgumentToHashPointer (&value_arg, value_type_info));
+        g_hash_table_insert (hash_table,
+                GIArgumentToHashPointer (&key_arg, key_type_info),
+                GIArgumentToHashPointer (&value_arg, value_type_info));
 
         continue;
 

--- a/tests/marshalling__ghashtable.js
+++ b/tests/marshalling__ghashtable.js
@@ -6,7 +6,6 @@
  * GHashTable marshals to/from a plain JS object (keys are stringified).
  *
  * KNOWN ISSUES (skip()'d below, kept for when they're fixed):
- *   - integer-keyed/valued GHashTable IN segfaults (#402)
  *   - transfer-container IN corrupts the heap (#399)
  *   - *OutUninitialized out-params segfault (#400)
  */
@@ -38,13 +37,13 @@ describe('ghashtable utf8 inout (none)', () => {
   expect(m.ghashtableUtf8NoneInout(UTF8_HASH), UTF8_INOUT_RESULT)
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #402 — integer GHashTable IN segfaults (value-vs-pointer packing).
-describe('ghashtable int none in (#402)', () => {
+// Integer-keyed/valued GHashTable IN — keys/values packed via GINT_TO_POINTER.
+describe('ghashtable int none in', () => {
   m.ghashtableIntNoneIn(INT_HASH)
 })
+
+// Everything below crashes — see the file header.
+skip()
 
 // #399 — transfer-container IN corrupts the heap.
 describe('ghashtable utf8 container in (#399)', () => {


### PR DESCRIPTION
## Summary

Fixes #402. Passing a JS object as a `GHashTable` with **integer** keys/values IN segfaulted (`ghashtableIntNoneIn` → exit 139).

`V8ToGHash` packed integer keys by copying `GIArgument.v_pointer` verbatim and selected `g_int_hash`/`g_int_equal` (or `g_int64_hash`) for the table. Those hash/equal functions **dereference** their argument as a pointer-to-integer, but the key holds the integer *value*, not a pointer to one — so `g_hash_table_insert` crashed. (Copying `v_pointer` also dropped the sign extension: `v_int = -1` gives `0x00000000ffffffff`, whereas the C side looks up `GINT_TO_POINTER(-1)` = `0xffffffffffffffff`.)

The **value** was already packed correctly via `GINT_TO_POINTER` (`GIArgumentToHashPointer`). This change makes the **key** use the same `GIArgumentToHashPointer` convention, and selects `g_direct_hash`/`g_direct_equal` for the integer and `GType` key tags — matching the GObject-introspection convention that the read path (`HashPointerToGIArgument`) and the C side already rely on.

## Test

Un-skips the integer-GHashTable-IN case in `tests/marshalling__ghashtable.js`. Verified locally:

- `ghashtableIntNoneIn`, `ghashtableUtf8NoneIn/FullIn/NoneInout`, `ghashtableIntNoneReturn` all pass.
- No regressions across the `marshalling__*` suite.

(`#399`/`#400` GHashTable cases remain `skip()`'d in the same file — separate issues.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)