### PR TITLE
feat: implement JS array -> GPtrArray IN/inout marshalling (#401)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -450,6 +450,36 @@ GArray * V8ToGArray(GITypeInfo *type_info, Local<Value> value) {
     return g_array;
 }
 
+GPtrArray * V8ToGPtrArray(GITypeInfo *type_info, Local<Value> value) {
+    if (!value->IsArray()) {
+        Nan::ThrowTypeError("Expected an array.");
+        return NULL;
+    }
+
+    auto array = Local<Array>::Cast (TO_OBJECT (value));
+    int length = array->Length();
+
+    GITypeInfo *element_info = g_type_info_get_param_type (type_info, 0);
+    GPtrArray *ptr_array = g_ptr_array_sized_new (length);
+
+    for (int i = 0; i < length; i++) {
+        auto element = Nan::Get(array, i).ToLocalChecked();
+        GIArgument arg;
+
+        // A GPtrArray always stores its elements as pointers, so each element
+        // is converted to its pointer representation (e.g. g_strdup'd string,
+        // GObject/boxed pointer) and added directly.
+        if (V8ToGIArgument(element_info, &arg, element, false)) {
+            g_ptr_array_add (ptr_array, arg.v_pointer);
+        } else {
+            g_warning("V8ToGPtrArray: couldnt convert value at index %i", i);
+        }
+    }
+
+    g_base_info_unref (element_info);
+    return ptr_array;
+}
+
 static void *V8ArrayToCArray(GITypeInfo *type_info, Local<Value> value) {
     auto array = Local<Array>::Cast (TO_OBJECT (value));
     int length = array->Length();
@@ -825,6 +855,8 @@ bool V8ToGIArgument(GITypeInfo *type_info, GIArgument *arg, Local<Value> value, 
                 arg->v_pointer = V8ToGArray(type_info, value);
                 break;
             case GI_ARRAY_TYPE_PTR_ARRAY:
+                arg->v_pointer = V8ToGPtrArray(type_info, value);
+                break;
             default:
                 printf("%s", Util::ArrayTypeToString(array_type));
                 g_assert_not_reached ();
@@ -1363,9 +1395,15 @@ void FreeGIArgumentArray(GITypeInfo *type_info, GIArgument *arg, GITransfer tran
             }
         case GI_ARRAY_TYPE_ARRAY:
         case GI_ARRAY_TYPE_BYTE_ARRAY:
+            {
+                // Free the container struct, not `data`, which may have been
+                // reassigned to the inner buffer in the free-elements block.
+                g_array_free ((GArray*) arg->v_pointer, TRUE);
+                break;
+            }
         case GI_ARRAY_TYPE_PTR_ARRAY:
             {
-                g_array_free ((GArray*)data, TRUE);
+                g_ptr_array_free ((GPtrArray*) arg->v_pointer, TRUE);
                 break;
             }
         default:

--- a/tests/marshalling__garray.js
+++ b/tests/marshalling__garray.js
@@ -5,12 +5,11 @@
  * transfer modes using the gobject-introspection GIMarshallingTests library.
  * Both marshal to/from plain JS arrays.
  *
- * KNOWN ISSUE (skip()'d below): GPtrArray IN/inout marshalling is unimplemented
- * and aborts at value.cc:823 (#401). GPtrArray OUT/return work fine; GArray
- * works in every direction.
+ * Both GArray and GPtrArray are exercised in every direction and transfer
+ * mode.
  */
 
-const { describe, expect, skip } = require('./__common__.js')
+const { describe, expect } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -50,11 +49,12 @@ describe('gptrarray utf8 return/out (none/full)', () => {
   expect(m.gptrarrayUtf8NoneOut(), STRS)
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #401 — GPtrArray IN/inout marshalling is unimplemented (value.cc:823).
-describe('gptrarray utf8 in/inout (#401)', () => {
+describe('gptrarray utf8 in (none/full/container)', () => {
   m.gptrarrayUtf8NoneIn(STRS)
-  m.gptrarrayUtf8NoneInout(STRS)
+  m.gptrarrayUtf8FullIn(STRS)
+  m.gptrarrayUtf8ContainerIn(STRS)
+})
+
+describe('gptrarray utf8 inout (none -> [-2,-1,0,1])', () => {
+  expect(m.gptrarrayUtf8NoneInout(STRS), UTF8_INOUT_RESULT)
 })


### PR DESCRIPTION
## Summary

Fixes #401. Passing a JS array to a `GPtrArray` **IN** (or the IN side of an **inout**) argument aborted:

```
ERROR:../src/value.cc:823: code should not be reached
```

The `GI_ARRAY_TYPE_PTR_ARRAY` branch of `V8ToGIArgument` was never implemented — only `GArray` and C arrays were. `GPtrArray` OUT/return already worked.

### Changes
- **`V8ToGPtrArray`**: converts each JS array element to its pointer representation (`g_strdup`'d string, GObject/boxed pointer, …) and appends it to a `GPtrArray`. Wired into the array switch.
- **`FreeGIArgumentArray` container free**: a `GPtrArray` was being freed with `g_array_free` (incompatible struct layout); now uses `g_ptr_array_free`. The `GArray`/`GPtrArray` container is also freed from the original container pointer instead of `data`, which may have been reassigned to the inner element buffer by the free-elements pass.

## Test

Un-skips the GPtrArray IN/inout cases in `tests/marshalling__garray.js`. Verified locally:

- `gptrarrayUtf8NoneIn` / `FullIn` / `ContainerIn` and `gptrarrayUtf8NoneInout` (→ `['-2','-1','0','1']`) all pass.
- No double-free on the container/full transfers.
- No regressions across the `marshalling__*` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)