### PR TITLE
chore: untrack accidentally-committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 .idea
 *~
-node_modules/
+node_modules
 */.tags
 \#*\#
 .buildconfig

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/romgrk/src/node-gtk/node_modules


### PR DESCRIPTION
PR #406 accidentally committed a `node_modules` symlink. It happened because `git add -A` was run in a worktree whose `node_modules` was a symlink, and `.gitignore` listed `node_modules/` with a **trailing slash**, which matches directories only — not a symlink. On checkout this symlink replaced any real `node_modules` directory (and pointed at itself, becoming circular).

This untracks it and drops the trailing slash so both a directory and a symlink named `node_modules` are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)