### PR TITLE
fix: marshal JS array to C array of structs by value (#404)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -458,6 +458,22 @@ static void *V8ArrayToCArray(GITypeInfo *type_info, Local<Value> value) {
     GITypeInfo* element_info = g_type_info_get_param_type (type_info, 0);
     gsize element_size = GetTypeSize(element_info);
 
+    // When the element is a struct/union/boxed passed by *value* (not a
+    // pointer), the C array stores the struct contents inline, so each
+    // element's bytes must be copied from the wrapped instance rather than
+    // copying the GIArgument (which only holds a pointer to it).
+    bool element_is_struct_by_value = false;
+    if (!g_type_info_is_pointer(element_info)
+            && g_type_info_get_tag(element_info) == GI_TYPE_TAG_INTERFACE) {
+        GIBaseInfo* interface_info = g_type_info_get_interface(element_info);
+        GIInfoType  interface_type = g_base_info_get_type(interface_info);
+        element_is_struct_by_value =
+               interface_type == GI_INFO_TYPE_STRUCT
+            || interface_type == GI_INFO_TYPE_BOXED
+            || interface_type == GI_INFO_TYPE_UNION;
+        g_base_info_unref(interface_info);
+    }
+
     void *result = g_malloc0(element_size * (length + (isZeroTerminated ? 1 : 0)));
 
     for (int i = 0; i < length; i++) {
@@ -467,7 +483,10 @@ static void *V8ArrayToCArray(GITypeInfo *type_info, Local<Value> value) {
 
         if (V8ToGIArgument(element_info, &arg, value, true)) {
             void* pointer = (void*)((size_t)result + i * element_size);
-            memcpy(pointer, &arg, element_size);
+            if (element_is_struct_by_value && arg.v_pointer != NULL)
+                memcpy(pointer, arg.v_pointer, element_size);
+            else
+                memcpy(pointer, &arg, element_size);
         } else {
             WARN("couldnt convert value: %s", *Nan::Utf8String(TO_STRING (value)));
         }

--- a/tests/marshalling__struct.js
+++ b/tests/marshalling__struct.js
@@ -4,10 +4,14 @@
  * Exercises struct and union marshalling using the gobject-introspection
  * GIMarshallingTests library: simple/pointer/boxed structs and a union, their
  * field getters (camelCased, so long_ -> long, string_ -> string, g_strv ->
- * gStrv), instance methods, construction, and array-in.
+ * gStrv), instance methods, construction, and array-in (both as an array of
+ * struct pointers and as a contiguous array of struct values).
  *
- * KNOWN ISSUE (skip()'d below): an array of structs passed by *value* IN is
- * mismarshalled (#404). The array-of-pointers forms work and are tested above.
+ * NOTE: this file ends in skip() (exit 222 / pending) because the suite
+ * segfaults at *process teardown* — after every test has passed — due to a
+ * pre-existing boxed-struct finalization bug (#409). Every test above the
+ * skip() runs and is verified; the skip() merely exits before the crashing
+ * V8 teardown.
  */
 
 const { describe, expect, assert, skip } = require('./__common__.js')
@@ -66,13 +70,12 @@ describe('array of struct pointers in (none/take)', () => {
   m.arrayStructTakeIn([mk(1), mk(2), mk(3)]) // transfer full
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #404 — array of structs by value IN is mismarshalled (garbage contents).
-describe('array of structs by value in (#404)', () => {
+describe('array of structs by value in', () => {
   const mkS = (n) => { const s = new m.SimpleStruct(); s.long = n; return s }
   const mkB = (n) => { const s = new m.BoxedStruct(); s.long = n; return s }
   m.arraySimpleStructIn([mkS(1), mkS(2), mkS(3)])
   m.arrayStructValueIn([mkB(1), mkB(2), mkB(3)])
 })
+
+// Exit before V8 teardown, which segfaults on boxed-struct finalization (#409).
+skip()


### PR DESCRIPTION
## Summary

Fixes #404. Passing a JS array of struct instances as a C **array of structs by value** (a contiguous block of struct *values*, not an array of pointers) produced garbage struct contents:

```
arraySimpleStructIn([...]) → assertion failed (structs[0].long_ == 1): (289536304 == 1)
```

`V8ArrayToCArray` `memcpy`'d the `GIArgument` into each element slot. For a struct element the `GIArgument` only holds a **pointer** to the instance, so the array ended up filled with pointer bytes instead of struct contents.

### Fix
Detect the by-value composite case — a non-pointer `struct`/`union`/`boxed` element — and `memcpy` `element_size` bytes from the wrapped instance (`arg.v_pointer`) into each slot. Primitive- and pointer-element arrays are unchanged (their value lives in the `GIArgument` union, or *is* the pointer, respectively).

## Test

Un-skips `arraySimpleStructIn` / `arrayStructValueIn` in `tests/marshalling__struct.js` (the array-of-pointers forms `arrayStructIn` / `arrayStructTakeIn` already worked and are still tested).

The file keeps a trailing `skip()` — as it did before — to exit before an **unrelated** boxed-struct finalization segfault that occurs at V8 process teardown (filed separately as #409). Every test above the skip runs and passes; CI status for this file is unchanged (it was already `pending`).

No regressions across the `marshalling__*` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)