### PR TITLE
fix: marshal a NULL GHashTable out-param to an empty object (#400)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -212,6 +212,18 @@ Local<Value> GHashToV8 (GITypeInfo *type_info, GHashTable *hash_table) {
 
     Local<Object> object = New<Object>();
 
+    // A NULL table marshals to an empty object. This notably happens for
+    // *_out_uninitialized functions, which return FALSE and leave their (out)
+    // pointer untouched (i.e. NULL, as the slot is zero-initialized). The
+    // GList/GSList/C-array converters already tolerate NULL; without this
+    // guard g_hash_table_iter_init asserts and the iterator is left
+    // uninitialized (#400).
+    if (hash_table == NULL) {
+        g_base_info_unref(key_info);
+        g_base_info_unref(value_info);
+        return object;
+    }
+
     GHashTableIter iter;
     GIArgument key_arg;
     GIArgument value_arg;

--- a/tests/marshalling__ghashtable.js
+++ b/tests/marshalling__ghashtable.js
@@ -5,12 +5,11 @@
  * modes using the gobject-introspection GIMarshallingTests library. A
  * GHashTable marshals to/from a plain JS object (keys are stringified).
  *
- * KNOWN ISSUES (skip()'d below, kept for when they're fixed):
+ * KNOWN ISSUE (skip()'d below, kept for when it's fixed):
  *   - transfer-container IN corrupts the heap (#399)
- *   - *OutUninitialized out-params segfault (#400)
  */
 
-const { describe, expect, skip } = require('./__common__.js')
+const { describe, expect, assert, skip } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -42,15 +41,18 @@ describe('ghashtable int none in', () => {
   m.ghashtableIntNoneIn(INT_HASH)
 })
 
+// Returns FALSE and leaves the (out) table pointer untouched (NULL); the
+// binding must not dereference it, and marshals it to an empty object.
+describe('ghashtable utf8 container out uninitialized (returns [false, {}])', () => {
+  const [ok, value] = m.ghashtableUtf8ContainerOutUninitialized()
+  assert(ok === false, `ghashtableUtf8ContainerOutUninitialized return should be false, got ${ok}`)
+  expect(value, {})
+})
+
 // Everything below crashes — see the file header.
 skip()
 
 // #399 — transfer-container IN corrupts the heap.
 describe('ghashtable utf8 container in (#399)', () => {
   m.ghashtableUtf8ContainerIn(UTF8_HASH)
-})
-
-// #400 — uninitialized pointer out-param is marshalled anyway, segfault.
-describe('ghashtable utf8 container out uninitialized (#400)', () => {
-  m.ghashtableUtf8ContainerOutUninitialized()
 })

--- a/tests/marshalling__glist.js
+++ b/tests/marshalling__glist.js
@@ -5,12 +5,11 @@
  * modes (none/full/container) using the gobject-introspection GIMarshallingTests
  * library. Both list types marshal to/from plain JS arrays.
  *
- * KNOWN ISSUES (skip()'d below, kept for when they're fixed):
+ * KNOWN ISSUE (skip()'d below, kept for when it's fixed):
  *   - transfer-container IN corrupts the heap (#399)
- *   - *OutUninitialized out-params segfault (#400)
  */
 
-const { describe, expect, skip } = require('./__common__.js')
+const { describe, expect, assert, skip } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -69,6 +68,17 @@ describe('gslist utf8 inout (none/full/container -> [-2,-1,0,1])', () => {
   expect(m.gslistUtf8ContainerInout(STRS), INOUT_RESULT)
 })
 
+// These return FALSE and leave the (out) list pointer untouched (NULL); the
+// binding must not dereference it, and marshals it to an empty array.
+describe('glist/gslist utf8 none out uninitialized (returns [false, []])', () => {
+  const [glistOk, glistVal] = m.glistUtf8NoneOutUninitialized()
+  assert(glistOk === false, `glistUtf8NoneOutUninitialized return should be false, got ${glistOk}`)
+  expect(glistVal, [])
+  const [gslistOk, gslistVal] = m.gslistUtf8NoneOutUninitialized()
+  assert(gslistOk === false, `gslistUtf8NoneOutUninitialized return should be false, got ${gslistOk}`)
+  expect(gslistVal, [])
+})
+
 // Everything below crashes — see the file header.
 skip()
 
@@ -76,10 +86,4 @@ skip()
 describe('glist/gslist utf8 container in (#399)', () => {
   m.glistUtf8ContainerIn(STRS)
   m.gslistUtf8ContainerIn(STRS)
-})
-
-// #400 — uninitialized pointer out-param is marshalled anyway, segfault.
-describe('glist/gslist utf8 none out uninitialized (#400)', () => {
-  m.glistUtf8NoneOutUninitialized()
-  m.gslistUtf8NoneOutUninitialized()
 })


### PR DESCRIPTION
## Summary

Fixes #400. The `*_out_uninitialized` GIMarshallingTests functions return `FALSE` and leave their `(out)` pointer **untouched**. node-gtk zero-initializes the callee-allocates out-arg slot (`function.cc`), so the binding sees a `NULL` pointer.

`GListToV8` / `GSListToV8` / `ArrayToV8` already tolerate `NULL` and produce an empty result, but `GHashToV8` called `g_hash_table_iter_init` on the `NULL` table — which asserts (`GLib-CRITICAL: assertion 'hash_table != NULL' failed`) and leaves the iterator uninitialized, undefined behavior that could crash.

### Fix
Guard `GHashToV8` against a `NULL` table and return an empty object, matching the other container converters.

## Test

Un-skips the `*OutUninitialized` cases in `tests/marshalling__glist.js` (glist/gslist → `[false, []]`) and `tests/marshalling__ghashtable.js` (→ `[false, {}]`), each now asserting the return value and empty container.

The transfer-container IN cases (#399) remain `skip()`'d in both files. No regressions across the `marshalling__*` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)