### PR TITLE
fix: unbox array-of-GValue returns instead of overflowing the stack (#398)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -287,6 +287,14 @@ static bool isZero(GIArgument &value, GITypeInfo *type_info) {
     }
 }
 
+static bool IsZeroMemory (const void *ptr, gsize size) {
+    const guint8 *bytes = (const guint8 *) ptr;
+    for (gsize i = 0; i < size; i++)
+        if (bytes[i] != 0)
+            return false;
+    return true;
+}
+
 Local<Value> ArrayToV8 (GITypeInfo *type_info, void* data, long length) {
 
     auto array = New<Array>();
@@ -298,6 +306,26 @@ Local<Value> ArrayToV8 (GITypeInfo *type_info, void* data, long length) {
     auto item_type_info = g_type_info_get_param_type (type_info, 0);
     auto item_size = GetTypeSize (item_type_info);
     // auto item_transfer = transfer == GI_TRANSFER_CONTAINER ? GI_TRANSFER_NOTHING : transfer;
+
+    // Composite values (a struct/union/boxed passed by value, e.g. an array of
+    // GValue) are stored inline and may be larger than a GIArgument, so they
+    // must not be memcpy'd into one — that overflows the stack (#398). Detect
+    // them up front so the fill loop can read them in place instead.
+    bool element_is_value_struct = false;
+    bool element_is_gvalue = false;
+    if (g_type_info_get_tag (item_type_info) == GI_TYPE_TAG_INTERFACE
+            && !g_type_info_is_pointer (item_type_info)) {
+        GIBaseInfo *element_interface = g_type_info_get_interface (item_type_info);
+        GIInfoType  element_interface_type = g_base_info_get_type (element_interface);
+        if (element_interface_type == GI_INFO_TYPE_STRUCT
+                || element_interface_type == GI_INFO_TYPE_BOXED
+                || element_interface_type == GI_INFO_TYPE_UNION) {
+            element_is_value_struct = true;
+            element_is_gvalue =
+                g_registered_type_info_get_g_type (element_interface) == G_TYPE_VALUE;
+        }
+        g_base_info_unref (element_interface);
+    }
 
     switch (array_type) {
         case GI_ARRAY_TYPE_C:
@@ -349,13 +377,27 @@ Local<Value> ArrayToV8 (GITypeInfo *type_info, void* data, long length) {
         if (length != -1 && i >= length)
             break;
 
-        void** pointer = (void**)((size_t)data + i * item_size);
-        memcpy(&value, pointer, item_size);
+        void* element_ptr = (void*)((size_t)data + i * item_size);
 
-        if (length == -1 && isZero(value, item_type_info))
-            break;
+        if (element_is_value_struct) {
+            // A zero-terminated array of values ends on an all-zero element.
+            if (length == -1 && IsZeroMemory(element_ptr, item_size))
+                break;
 
-        Nan::Set(array, i, GIArgumentToV8(item_type_info, &value));
+            if (element_is_gvalue) {
+                Nan::Set(array, i, GValueToV8((GValue*) element_ptr));
+            } else {
+                value.v_pointer = element_ptr;
+                Nan::Set(array, i, GIArgumentToV8(item_type_info, &value));
+            }
+        } else {
+            memcpy(&value, element_ptr, item_size);
+
+            if (length == -1 && isZero(value, item_type_info))
+                break;
+
+            Nan::Set(array, i, GIArgumentToV8(item_type_info, &value));
+        }
     }
 
 

--- a/tests/marshalling__gvalue.js
+++ b/tests/marshalling__gvalue.js
@@ -9,17 +9,13 @@
  * GObject.Value. A GValue coming back OUT is a GObject.Value whose contents are
  * read with the typed getters (getInt, getInt64, getString, ...).
  *
- * KNOWN ISSUE — returnGvalueFlatArray() and returnGvalueZeroTerminatedArray()
- * (a GValue* treated as a C array of GValue) segfault: node-gtk mismarshals
- * the array-of-GValue return. A segfault is an uncatchable process abort, so
- * those two cases are skip()'d (everything above the skip still runs and stays
- * enforced). Tracked in https://github.com/romgrk/node-gtk/issues/398; remove
- * the skip() once fixed.
+ * Also covers a GValue* returned as a (flat / zero-terminated) C array of
+ * GValue, which is unboxed element-by-element to plain JS values.
  */
 
 const gi = require('../lib/')
 const GObject = gi.require('GObject', '2.0')
-const { describe, expect, assert, skip } = require('./__common__.js')
+const { describe, expect, assert } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -79,9 +75,6 @@ describe('gvalue noncanonical NaN (float/double)', () => {
   assert(Number.isNaN(m.gvalueNoncanonicalNanDouble().getDouble()),
     'gvalueNoncanonicalNanDouble should hold NaN')
 })
-
-// Everything below segfaults (issue #398) — see the file header.
-skip()
 
 describe('gvalue flat array return ([42, "42", true])', () => {
   expect(m.returnGvalueFlatArray(), [42, '42', true])


### PR DESCRIPTION
## Summary

Fixes #398. A `GValue*` returned as a C array of `GValue` (`returnGvalueFlatArray`, `returnGvalueZeroTerminatedArray`) crashed.

`ArrayToV8` `memcpy`'d each element into a `GIArgument`, but a `GValue` is 24 bytes and a `GIArgument` is 8 — the copy **overflowed the stack** (uncatchable abort / segfault, non-deterministic). Even when it happened not to crash, each element came back as an opaque boxed `{}` instead of its value.

### Fix
Composite elements (a struct/union/boxed stored inline *by value*) can be larger than a `GIArgument`, so they must be read in place. `ArrayToV8` now detects that case up front and:
- for `GValue` elements, unboxes each with `GValueToV8`;
- for other by-value structs, wraps from the in-array address rather than copying into a `GIArgument`.

Zero-terminated arrays of values terminate on an all-zero element.

## Test

Un-skips the flat / zero-terminated GValue-array cases in `tests/marshalling__gvalue.js` (both now return `[42, '42', true]`, verified deterministically). No regressions across the `marshalling__*` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)