### PR TITLE
fix: transfer-container IN of GList/GSList/GHashTable corrupts the heap (#399)

### DIFF
--- a/src/function.cc
+++ b/src/function.cc
@@ -440,6 +440,15 @@ Local<Value> FunctionCall (
                     param.data.v_pointer = callable_arg_values[i].v_pointer;
                     callable_arg_values[i].v_pointer = &param.data;
                 }
+                // For a transfer-container IN GList/GSList/GHashTable the callee
+                // frees the container; snapshot the (caller-owned) element
+                // pointers now so they can be freed after the call (#399).
+                else if (IsTransferContainerInList(&type_info,
+                            g_arg_info_get_ownership_transfer(&arg_info), direction)) {
+                    param.data = {};
+                    param.data.v_pointer = CaptureTransferContainerElements(
+                            &type_info, callable_arg_values[i].v_pointer);
+                }
             }
 
             in_arg++;
@@ -537,6 +546,11 @@ Local<Value> FunctionCall (
             if (callback && callback->scope_type == GI_SCOPE_TYPE_CALL) {
                 delete callback;
             }
+        }
+        else if (IsTransferContainerInList (&arg_type, transfer, direction)) {
+            // The callee already freed the container structure; free only the
+            // captured (caller-owned) elements, never the freed container (#399).
+            FreeTransferContainerElements (&arg_type, param.data.v_pointer);
         }
         else {
             if (direction == GI_DIRECTION_INOUT || (direction == GI_DIRECTION_OUT && !g_arg_info_is_caller_allocates (&arg_info)))

--- a/src/value.cc
+++ b/src/value.cc
@@ -1486,6 +1486,98 @@ void FreeGIArgumentArray(GITypeInfo *type_info, GIArgument *arg, GITransfer tran
     }
 }
 
+/*
+ * Transfer-container IN cleanup for GList/GSList/GHashTable.
+ *
+ * With transfer-container, the callee takes ownership of (and frees) the
+ * container structure but NOT its elements, which the caller still owns. By
+ * the time node-gtk runs its post-call cleanup the container has already been
+ * freed, so it can no longer be walked to reach the (owned) elements — doing
+ * so corrupts the heap (#399). Instead we snapshot the element pointers into a
+ * private structure *before* the call and free them from that snapshot after.
+ */
+
+struct CapturedContainer {
+    GList  *list;    // GLIST: copied node chain; GHASH: keys
+    GSList *slist;   // GSLIST: copied node chain
+    GList  *values;  // GHASH: values
+};
+
+bool IsTransferContainerInList (GITypeInfo *type_info, GITransfer transfer, GIDirection direction) {
+    if (direction != GI_DIRECTION_IN || transfer != GI_TRANSFER_CONTAINER)
+        return false;
+
+    switch (g_type_info_get_tag (type_info)) {
+        case GI_TYPE_TAG_GLIST:
+        case GI_TYPE_TAG_GSLIST:
+        case GI_TYPE_TAG_GHASH:
+            return true;
+        default:
+            return false;
+    }
+}
+
+gpointer CaptureTransferContainerElements (GITypeInfo *type_info, gpointer container) {
+    if (container == NULL)
+        return NULL;
+
+    CapturedContainer *captured = g_new0 (CapturedContainer, 1);
+
+    switch (g_type_info_get_tag (type_info)) {
+        case GI_TYPE_TAG_GLIST:
+            captured->list = g_list_copy ((GList *) container);
+            break;
+        case GI_TYPE_TAG_GSLIST:
+            captured->slist = g_slist_copy ((GSList *) container);
+            break;
+        case GI_TYPE_TAG_GHASH:
+            captured->list   = g_hash_table_get_keys ((GHashTable *) container);
+            captured->values = g_hash_table_get_values ((GHashTable *) container);
+            break;
+        default:
+            break;
+    }
+
+    return captured;
+}
+
+void FreeTransferContainerElements (GITypeInfo *type_info, gpointer captured_ptr) {
+    if (captured_ptr == NULL)
+        return;
+
+    CapturedContainer *captured = (CapturedContainer *) captured_ptr;
+    GITypeTag   type_tag = g_type_info_get_tag (type_info);
+    GITypeInfo *key_info = g_type_info_get_param_type (type_info, 0);
+    GIArgument  element;
+
+    if (type_tag == GI_TYPE_TAG_GSLIST) {
+        for (GSList *l = captured->slist; l != NULL; l = l->next) {
+            element.v_pointer = l->data;
+            FreeGIArgument (key_info, &element, GI_TRANSFER_EVERYTHING, GI_DIRECTION_OUT);
+        }
+        g_slist_free (captured->slist);
+    } else {
+        for (GList *l = captured->list; l != NULL; l = l->next) {
+            element.v_pointer = l->data;
+            FreeGIArgument (key_info, &element, GI_TRANSFER_EVERYTHING, GI_DIRECTION_OUT);
+        }
+        g_list_free (captured->list);
+    }
+    g_base_info_unref (key_info);
+
+    if (type_tag == GI_TYPE_TAG_GHASH) {
+        GITypeInfo *value_info = g_type_info_get_param_type (type_info, 1);
+        for (GList *l = captured->values; l != NULL; l = l->next) {
+            element.v_pointer = l->data;
+            FreeGIArgument (value_info, &element, GI_TRANSFER_EVERYTHING, GI_DIRECTION_OUT);
+        }
+        g_base_info_unref (value_info);
+        g_list_free (captured->values);
+    }
+
+    g_free (captured);
+}
+
 
 /*
  * GValue conversion functions

--- a/src/value.h
+++ b/src/value.h
@@ -30,6 +30,14 @@ bool         V8ToGIArgument (GITypeInfo *type_info, GIArgument *argument, Local<
 bool         V8ToOutGIArgument(GITypeInfo *type_info, GIArgument *arg, Local<Value> value, bool may_be_null);
 void         FreeGIArgument (GITypeInfo *type_info, GIArgument *argument, GITransfer transfer = GI_TRANSFER_EVERYTHING, GIDirection direction = GI_DIRECTION_OUT);
 void         FreeGIArgumentArray (GITypeInfo *type_info, GIArgument *arg, GITransfer transfer = GI_TRANSFER_EVERYTHING, GIDirection direction = GI_DIRECTION_OUT, long length = -1);
+
+// For a transfer-container IN GList/GSList/GHashTable, the callee frees the
+// container structure itself, so node-gtk cannot walk it afterwards to free
+// the (caller-owned) elements. These capture the element pointers *before*
+// the call so they can be freed *after* it. See #399.
+bool         IsTransferContainerInList (GITypeInfo *type_info, GITransfer transfer, GIDirection direction);
+gpointer     CaptureTransferContainerElements (GITypeInfo *type_info, gpointer container);
+void         FreeTransferContainerElements (GITypeInfo *type_info, gpointer captured);
 bool         CanConvertV8ToGIArgument (GITypeInfo *type_info, Local<Value> value, bool may_be_null);
 
 bool         V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership = kNone);

--- a/tests/marshalling__ghashtable.js
+++ b/tests/marshalling__ghashtable.js
@@ -4,12 +4,9 @@
  * Exercises GHashTable marshalling in every direction and across transfer
  * modes using the gobject-introspection GIMarshallingTests library. A
  * GHashTable marshals to/from a plain JS object (keys are stringified).
- *
- * KNOWN ISSUE (skip()'d below, kept for when it's fixed):
- *   - transfer-container IN corrupts the heap (#399)
  */
 
-const { describe, expect, assert, skip } = require('./__common__.js')
+const { describe, expect, assert } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -49,10 +46,8 @@ describe('ghashtable utf8 container out uninitialized (returns [false, {}])', ()
   expect(value, {})
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #399 — transfer-container IN corrupts the heap.
-describe('ghashtable utf8 container in (#399)', () => {
+// transfer-container IN: the callee frees the table, node-gtk frees the
+// (caller-owned) key/value strings it captured before the call.
+describe('ghashtable utf8 container in', () => {
   m.ghashtableUtf8ContainerIn(UTF8_HASH)
 })

--- a/tests/marshalling__glist.js
+++ b/tests/marshalling__glist.js
@@ -4,12 +4,9 @@
  * Exercises GList and GSList marshalling in every direction and across transfer
  * modes (none/full/container) using the gobject-introspection GIMarshallingTests
  * library. Both list types marshal to/from plain JS arrays.
- *
- * KNOWN ISSUE (skip()'d below, kept for when it's fixed):
- *   - transfer-container IN corrupts the heap (#399)
  */
 
-const { describe, expect, assert, skip } = require('./__common__.js')
+const { describe, expect, assert } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -79,11 +76,9 @@ describe('glist/gslist utf8 none out uninitialized (returns [false, []])', () =>
   expect(gslistVal, [])
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #399 — transfer-container IN corrupts the heap (double/invalid free).
-describe('glist/gslist utf8 container in (#399)', () => {
+// transfer-container IN: the callee frees the list nodes, node-gtk frees the
+// (caller-owned) string elements it captured before the call.
+describe('glist/gslist utf8 container in', () => {
   m.glistUtf8ContainerIn(STRS)
   m.gslistUtf8ContainerIn(STRS)
 })


### PR DESCRIPTION
## Summary

Fixes #399. Passing a JS array/object as a **transfer-container** IN argument for a `GList`, `GSList`, or `GHashTable` corrupted the heap (`double free or corruption`, `free(): invalid pointer`, `realloc(): invalid pointer`).

With transfer-container the callee takes ownership of (and frees) the **container structure** but not its **elements**, which the caller still owns:

```c
glist_utf8_container_in (GList *list)   { ...read...; g_list_free (list); }
ghashtable_utf8_container_in (GHashTable *h) { ...read...; g_hash_table_steal_all (h); g_hash_table_unref (h); }
```

node-gtk's post-call cleanup walked the container to free those caller-owned elements — but by then the callee had already freed it, so the walk read freed memory and corrupted the heap.

### Fix
Snapshot the element pointers into a private structure **before** the call (`CaptureTransferContainerElements`) and free them from that snapshot **after** the call (`FreeTransferContainerElements`), never touching the freed container. Element types are honored, so e.g. integer GHashTable keys/values (packed as `GINT_TO_POINTER`) are correctly left untouched rather than passed to `g_free`.

`GArray`/`GPtrArray` (handled via `FreeGIArgumentArray`) and transfer-none / transfer-full IN are unaffected.

## Test

Un-skips the transfer-container IN cases in `tests/marshalling__glist.js` and `tests/marshalling__ghashtable.js`. Both files now pass in full. Verified the three container-IN calls run cleanly (incl. forced GC) across repeated runs with no abort. No regressions across the `marshalling__*` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)