### PR TITLE
fix: marshal (out)/(inout) signal parameters correctly (#405)

### DIFF
--- a/src/closure.cc
+++ b/src/closure.cc
@@ -19,6 +19,41 @@ using Nan::Persistent;
 
 namespace GNodeJS {
 
+/*
+ * An (out)/(inout) signal parameter arrives as a GValue holding a *pointer* to
+ * the value (e.g. a gint* for an `(inout) (type int)` parameter), not the value
+ * itself. Dereference it in place so the argument holds the pointed-to value.
+ */
+static void LoadGIArgumentFromPointer (GITypeInfo *type_info, GIArgument *arg) {
+    gpointer ptr = arg->v_pointer;
+
+    if (ptr == NULL) {
+        memset(arg, 0, sizeof(*arg));
+        return;
+    }
+
+    switch (g_type_info_get_tag(type_info)) {
+        case GI_TYPE_TAG_BOOLEAN: arg->v_boolean = *(gboolean*) ptr; break;
+        case GI_TYPE_TAG_INT8:    arg->v_int8    = *(gint8*)    ptr; break;
+        case GI_TYPE_TAG_UINT8:   arg->v_uint8   = *(guint8*)   ptr; break;
+        case GI_TYPE_TAG_INT16:   arg->v_int16   = *(gint16*)   ptr; break;
+        case GI_TYPE_TAG_UINT16:  arg->v_uint16  = *(guint16*)  ptr; break;
+        case GI_TYPE_TAG_INT32:   arg->v_int32   = *(gint32*)   ptr; break;
+        case GI_TYPE_TAG_UNICHAR:
+        case GI_TYPE_TAG_UINT32:  arg->v_uint32  = *(guint32*)  ptr; break;
+        case GI_TYPE_TAG_INT64:   arg->v_int64   = *(gint64*)   ptr; break;
+        case GI_TYPE_TAG_UINT64:  arg->v_uint64  = *(guint64*)  ptr; break;
+        case GI_TYPE_TAG_FLOAT:   arg->v_float   = *(gfloat*)   ptr; break;
+        case GI_TYPE_TAG_DOUBLE:  arg->v_double  = *(gdouble*)  ptr; break;
+        case GI_TYPE_TAG_GTYPE:   arg->v_size    = *(gsize*)    ptr; break;
+        default:
+            // Pointer-like types (utf8, interface, array, list, ...): the value
+            // is itself a pointer stored at *ptr.
+            arg->v_pointer = *(gpointer*) ptr;
+            break;
+    }
+}
+
 GClosure *Closure::New (Local<Function> function, GICallableInfo* info, guint signalId) {
     Closure *closure = (Closure *) g_closure_new_simple (sizeof (*closure), GUINT_TO_POINTER(signalId));
     closure->persistent.Reset(function);
@@ -70,7 +105,16 @@ void Closure::Execute(GICallableInfo *info, guint signal_id,
                     ownership = kNone;
                 }
             }
-            if (g_arg_info_get_direction(&arg_info) == GI_DIRECTION_OUT) {
+
+            GIDirection direction = g_arg_info_get_direction(&arg_info);
+            if (direction == GI_DIRECTION_INOUT) {
+                // The GValue holds a pointer to the in/out value; dereference it
+                // so the handler receives the actual value (#405).
+                LoadGIArgumentFromPointer(&type_info, &argument);
+                ownership = kNone;
+            } else if (direction == GI_DIRECTION_OUT) {
+                // Pure out: there is no meaningful incoming value.
+                memset(&argument, 0, sizeof(argument));
                 ownership = kNone;
             }
 
@@ -104,7 +148,54 @@ void Closure::Execute(GICallableInfo *info, guint signal_id,
     if (!try_catch.HasCaught()
             && result.ToLocal(&return_value)) {
 
-        if (g_return_value) {
+        if (info) {
+            // Distribute the handler's return value across the signal's return
+            // value and its (out)/(inout) parameters, writing each back (#405).
+            // When there is more than one output the handler returns an array,
+            // mirroring how out-arguments are returned from a function call.
+            GIArgInfo  out_arg_info;
+            GITypeInfo out_type_info;
+
+            int n_outputs = (g_return_value != NULL) ? 1 : 0;
+            for (guint i = 1; i < n_param_values; i++) {
+                g_callable_info_load_arg(info, i - 1, &out_arg_info);
+                GIDirection d = g_arg_info_get_direction(&out_arg_info);
+                if (d == GI_DIRECTION_OUT || d == GI_DIRECTION_INOUT)
+                    n_outputs++;
+            }
+
+            bool from_array = n_outputs > 1 && return_value->IsArray();
+            int output_index = 0;
+
+            #define NEXT_OUTPUT() ( \
+                n_outputs <= 1 \
+                    ? return_value \
+                    : (from_array \
+                        ? Nan::Get(return_value.As<v8::Array>(), output_index++).ToLocalChecked() \
+                        : (output_index++, Nan::Undefined().As<Value>())))
+
+            if (g_return_value) {
+                if (!V8ToGValue (g_return_value, NEXT_OUTPUT(), kCopy))
+                    goto throw_exception;
+            }
+
+            for (guint i = 1; i < n_param_values; i++) {
+                g_callable_info_load_arg(info, i - 1, &out_arg_info);
+                GIDirection d = g_arg_info_get_direction(&out_arg_info);
+                if (d != GI_DIRECTION_OUT && d != GI_DIRECTION_INOUT)
+                    continue;
+
+                g_arg_info_load_type(&out_arg_info, &out_type_info);
+
+                GIArgument out_arg;
+                memcpy(&out_arg, &param_values[i].data[0], sizeof(GIArgument));
+                if (out_arg.v_pointer != NULL)
+                    V8ToOutGIArgument(&out_type_info, &out_arg, NEXT_OUTPUT(), true);
+            }
+
+            #undef NEXT_OUTPUT
+        }
+        else if (g_return_value) {
             if (!V8ToGValue (g_return_value, return_value, kCopy))
                 goto throw_exception;
         }

--- a/tests/regress__signal.js
+++ b/tests/regress__signal.js
@@ -6,13 +6,9 @@
  *
  * node-gtk passes only the signal's own parameters to a handler (it does NOT
  * prepend the emitting instance), so a VOID__VOID signal handler takes no args.
- *
- * KNOWN ISSUE (skip()'d below): inout signal parameters are mismarshalled
- * (#405) — the value passed to the handler is garbage and the handler's return
- * value is not written back into the inout parameter.
  */
 
-const { describe, expect, assert, skip } = require('./__common__.js')
+const { describe, expect, assert } = require('./__common__.js')
 const { requireRegress } = require('./__gi-fixtures__.js')
 
 const R = requireRegress()
@@ -43,13 +39,12 @@ describe('signal with int64 return value ("sig-with-int64-prop")', () => {
   assert(received !== undefined, 'handler should receive the int64 argument')
 })
 
-// Everything below crashes — see the file header.
-skip()
-
-// #405 — inout signal parameter is mismarshalled (garbage in, return not
-// written back), so the library's `inout == 43` assertion aborts.
-describe('signal with inout int ("sig-with-inout-int") (#405)', () => {
+// The inout gint* is dereferenced for the handler (which sees 42), and the
+// handler's return value is written back into it (the library asserts 43).
+describe('signal with inout int ("sig-with-inout-int")', () => {
   const o = new R.TestObj()
-  o.connect('sig-with-inout-int', (v) => v + 1)
-  o.emitSigWithInoutInt()
+  let received
+  o.connect('sig-with-inout-int', (v) => { received = v; return v + 1 })
+  o.emitSigWithInoutInt() // g_asserts the inout param became 43
+  expect(received, 42)
 })


### PR DESCRIPTION
## Summary

Fixes #405. An `(inout)` (or `(out)`) signal parameter arrives as a `GValue` holding a **pointer** to the value (e.g. a `gint*` for `(inout) (type int)`), but the closure marshaller treated the `GValue` payload as the value itself:

1. it read the pointer's low bits as the `int`, so the handler received **garbage** (e.g. `-482357468` instead of `42`);
2. it never wrote the handler's result **back** into the parameter.

### Fix
- **On read:** dereference the pointer for `(inout)` parameters (`LoadGIArgumentFromPointer`) so the handler receives the real value; pure `(out)` parameters get a zeroed argument.
- **On return:** distribute the handler's return value across the signal's return value and its `(out)`/`(inout)` parameters, writing each back via `V8ToOutGIArgument` — mirroring how a function call returns its out-arguments (a single output is the return value; multiple outputs are an array).

## Test

Un-skips the `sig-with-inout-int` case in `tests/regress__signal.js`: the handler now receives `42` and the library's `inout == 43` assertion passes. All other signal/closure tests (`signal*.js`, `regress__object.js`, callbacks) still pass — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)