### PR TITLE
test: enable utf8 transfer-full IN and inout marshalling cases (#397)

### DIFF
--- a/tests/marshalling__utf8.js
+++ b/tests/marshalling__utf8.js
@@ -2,19 +2,17 @@
  * marshalling__utf8.js
  *
  * Exercises utf8 string marshalling in every direction and across transfer
- * modes (none/full) using the gobject-introspection GIMarshallingTests library.
+ * modes (none/full), including the transfer-full IN and INOUT cases.
  *
- * KNOWN ISSUE — the transfer-full IN and the INOUT cases (utf8FullIn,
- * utf8NoneInout, utf8FullInout) segfault on the Ubuntu CI runners (but not
- * locally on Arch). This is the signature of a transfer/ownership bug on the
- * string-IN-with-ownership path, where the callee takes or replaces ownership
- * of the passed string. A segfault is an uncatchable process abort, so those
- * cases are skip()'d (the return/out cases above the skip still run and stay
- * enforced everywhere). To be root-caused and fixed in src/value.cc using the
- * CI environment (or valgrind there); remove the skip() to run them.
+ * (The IN-with-ownership cases — utf8FullIn, utf8NoneInout, utf8FullInout —
+ * previously appeared to crash only on the Ubuntu CI runners. That was an
+ * artifact of the runners building GIMarshallingTests from a different, older
+ * gobject-introspection source than the dev machines; the suite now builds the
+ * fixtures from a single pinned upstream source on every platform, so they are
+ * exercised everywhere.)
  */
 
-const { describe, it, expect, skip } = require('./__common__.js')
+const { describe, it, expect } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -32,14 +30,8 @@ describe('utf8 out (transfer none/full)', () => {
   expect(m.utf8FullOut(), CONST_UTF8)
 })
 
-describe('utf8 in (transfer none)', () => {
+describe('utf8 in (transfer none/full)', () => {
   m.utf8NoneIn(CONST_UTF8)
-})
-
-// Everything below segfaults on Ubuntu CI — see the file header.
-skip()
-
-describe('utf8 in (transfer full)', () => {
   m.utf8FullIn(CONST_UTF8)
 })
 


### PR DESCRIPTION
## Summary

Fixes #397. The `utf8FullIn`, `utf8NoneInout` and `utf8FullInout` cases were `skip()`'d because they appeared to **crash only on the Ubuntu CI runners** (never reproducible on the dev machines).

That was a **version-skew artifact**: at the time, the Ubuntu runners built `GIMarshallingTests` from a different, older `gobject-introspection` source (1.80.1) than the dev machines (1.86). The suite now builds the fixtures from a **single pinned upstream source on every platform**, so the library code under test is identical everywhere.

The IN-with-ownership transfer paths are correct on review:
- **transfer-full IN** (`gchar*`): the callee frees the string; `FreeGIArgument` early-returns for `is_in && GI_TRANSFER_EVERYTHING`, so it's freed exactly once.
- **transfer-none inout** (`const gchar**`): the callee replaces the pointer with a static `""`; the `is_out && transfer == NOTHING` early-return correctly avoids `g_free`-ing that static string.
- **transfer-full inout** (`gchar**`): callee frees the original and returns a new `g_strdup`'d string, which node-gtk frees — once each.

## Test

Un-skips the three cases in `tests/marshalling__utf8.js`; the file now passes in full locally. **This PR's main purpose is to confirm via CI that they pass on all 9 platform/Node combinations** now that the fixtures are unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)