### PR TITLE
fix: copy boxed arguments passed as transfer-full IN to avoid a double free (#409)

### DIFF
--- a/src/function.cc
+++ b/src/function.cc
@@ -449,6 +449,13 @@ Local<Value> FunctionCall (
                     param.data.v_pointer = CaptureTransferContainerElements(
                             &type_info, callable_arg_values[i].v_pointer);
                 }
+                // For a transfer-full IN boxed (or array of boxed) the callee
+                // frees the memory; hand it a copy so the JS wrapper's own
+                // memory isn't double-freed when it's finalized (#409).
+                else if (direction == GI_DIRECTION_IN
+                        && g_arg_info_get_ownership_transfer(&arg_info) == GI_TRANSFER_EVERYTHING) {
+                    CopyBoxedForTransferFullIn(&type_info, &callable_arg_values[i], param.length);
+                }
             }
 
             in_arg++;

--- a/src/value.cc
+++ b/src/value.cc
@@ -1578,6 +1578,62 @@ void FreeTransferContainerElements (GITypeInfo *type_info, gpointer captured_ptr
     g_free (captured);
 }
 
+// Returns the boxed GType of a struct/union/boxed interface type, or
+// G_TYPE_INVALID if `type_info` isn't a registered boxed type.
+static GType BoxedGTypeOf (GITypeInfo *type_info) {
+    if (g_type_info_get_tag(type_info) != GI_TYPE_TAG_INTERFACE)
+        return G_TYPE_INVALID;
+
+    GIBaseInfo *interface_info = g_type_info_get_interface(type_info);
+    GIInfoType  interface_type = g_base_info_get_type(interface_info);
+    GType       gtype = G_TYPE_INVALID;
+
+    if (interface_type == GI_INFO_TYPE_BOXED
+            || interface_type == GI_INFO_TYPE_STRUCT
+            || interface_type == GI_INFO_TYPE_UNION) {
+        GType registered = g_registered_type_info_get_g_type(interface_info);
+        if (G_TYPE_IS_BOXED(registered))
+            gtype = registered;
+    }
+
+    g_base_info_unref(interface_info);
+    return gtype;
+}
+
+void CopyBoxedForTransferFullIn (GITypeInfo *type_info, GIArgument *arg, long length) {
+    if (arg->v_pointer == NULL)
+        return;
+
+    GITypeTag type_tag = g_type_info_get_tag(type_info);
+
+    // A single boxed argument passed by value/pointer.
+    if (type_tag == GI_TYPE_TAG_INTERFACE) {
+        GType gtype = BoxedGTypeOf(type_info);
+        if (gtype != G_TYPE_INVALID)
+            arg->v_pointer = g_boxed_copy(gtype, arg->v_pointer);
+        return;
+    }
+
+    // A C array of boxed pointers (e.g. GIMarshallingTestsBoxedStruct **).
+    if (type_tag == GI_TYPE_TAG_ARRAY
+            && g_type_info_get_array_type(type_info) == GI_ARRAY_TYPE_C
+            && length >= 0) {
+        GITypeInfo *element_info = g_type_info_get_param_type(type_info, 0);
+
+        if (g_type_info_is_pointer(element_info)) {
+            GType gtype = BoxedGTypeOf(element_info);
+            if (gtype != G_TYPE_INVALID) {
+                gpointer *elements = (gpointer *) arg->v_pointer;
+                for (long i = 0; i < length; i++)
+                    if (elements[i] != NULL)
+                        elements[i] = g_boxed_copy(gtype, elements[i]);
+            }
+        }
+
+        g_base_info_unref(element_info);
+    }
+}
+
 
 /*
  * GValue conversion functions

--- a/src/value.h
+++ b/src/value.h
@@ -38,6 +38,14 @@ void         FreeGIArgumentArray (GITypeInfo *type_info, GIArgument *arg, GITran
 bool         IsTransferContainerInList (GITypeInfo *type_info, GITransfer transfer, GIDirection direction);
 gpointer     CaptureTransferContainerElements (GITypeInfo *type_info, gpointer container);
 void         FreeTransferContainerElements (GITypeInfo *type_info, gpointer captured);
+
+// For a transfer-full IN boxed argument (or a C array of boxed pointers) the
+// callee frees the passed memory, but the JS wrapper still owns its own copy,
+// which would then be double-freed when the wrapper is finalized. Replace each
+// such pointer with a g_boxed_copy so only the copy is handed to the callee.
+// See #409.
+void         CopyBoxedForTransferFullIn (GITypeInfo *type_info, GIArgument *arg, long length);
+
 bool         CanConvertV8ToGIArgument (GITypeInfo *type_info, Local<Value> value, bool may_be_null);
 
 bool         V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership = kNone);

--- a/tests/marshalling__struct.js
+++ b/tests/marshalling__struct.js
@@ -6,15 +6,9 @@
  * field getters (camelCased, so long_ -> long, string_ -> string, g_strv ->
  * gStrv), instance methods, construction, and array-in (both as an array of
  * struct pointers and as a contiguous array of struct values).
- *
- * NOTE: this file ends in skip() (exit 222 / pending) because the suite
- * segfaults at *process teardown* — after every test has passed — due to a
- * pre-existing boxed-struct finalization bug (#409). Every test above the
- * skip() runs and is verified; the skip() merely exits before the crashing
- * V8 teardown.
  */
 
-const { describe, expect, assert, skip } = require('./__common__.js')
+const { describe, expect, assert } = require('./__common__.js')
 const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 
 const m = requireGIMarshallingTests()
@@ -76,6 +70,3 @@ describe('array of structs by value in', () => {
   m.arraySimpleStructIn([mkS(1), mkS(2), mkS(3)])
   m.arrayStructValueIn([mkB(1), mkB(2), mkB(3)])
 })
-
-// Exit before V8 teardown, which segfaults on boxed-struct finalization (#409).
-skip()


### PR DESCRIPTION
## Summary

Fixes #409. Passing a boxed wrapper (or an array of them) to a **transfer-full IN** argument handed the callee the wrapper's *own* pointer. The callee then freed it — e.g. `gi_marshalling_tests_array_struct_take_in` `g_slice_free`s each struct — leaving the JS wrapper with `owns_memory == true` and a dangling pointer. `BoxedDestroyed` then freed it a **second time** at finalization.

Because the second free happens during finalization, in the test suite it surfaced as a hard crash at V8 **process teardown**:

```
#0  0x0000000000007097 in ??? ()
#1  node::PerIsolatePlatformData::Shutdown()
#2  node::NodePlatform::UnregisterIsolate(v8::Isolate*)
#3  node::NodeMainInstance::~NodeMainInstance()
```

(Removing just the `arrayStructTakeIn` call from the struct test made the teardown crash disappear — confirming the transfer-full boxed double-free as the cause.)

### Fix
Hand the callee a `g_boxed_copy` instead of the wrapper's pointer (`CopyBoxedForTransferFullIn`), covering both:
- a single `struct`/`union`/`boxed` argument, and
- a C array of boxed pointers (`GIMarshallingTestsBoxedStruct **`).

The callee frees the copy; the wrapper keeps its own memory and stays **valid and reusable** after the call (matching GJS/PyGObject). GObjects (ref-counted) and non-boxed types are untouched (gated on `G_TYPE_IS_BOXED` + `GI_TRANSFER_EVERYTHING` + `GI_DIRECTION_IN`).

## Test

With the double-free gone, `tests/marshalling__struct.js` no longer needs the teardown-avoiding `skip()` and now runs to normal exit — verified clean 8/8 (was crashing 6/6). Full suite: **0 fail, 0 skip** for marshalling (the only failing file, `require.js`, is a pre-existing local GLib-version quirk, green in CI). Verified copy semantics: a wrapper passed to `arrayStructTakeIn` is still valid (`.long` intact) and reusable afterward, and GC is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)