### PR TITLE
refactor: rename JS identifiers for readability

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -56,12 +56,12 @@ function extendBaseClass(BaseClass) {
     if (!this._listeners.has(event))
       this._listeners.set(event, new WeakMap())
 
-    const fnMap = this._listeners.get(event)
+    const callbackHandlerMap = this._listeners.get(event)
     const handlerID = this.connect(event, callback, after)
     if (handlerID === 0) {
       throw new Error(`Could not connect to signal ${event}`)
     }
-    fnMap.set(callback, handlerID)
+    callbackHandlerMap.set(callback, handlerID)
     return this
   }
 
@@ -71,13 +71,13 @@ function extendBaseClass(BaseClass) {
     if (!this._listeners.has(event))
       return
 
-    const fnMap = this._listeners.get(event)
-    if (!fnMap.has(callback))
+    const callbackHandlerMap = this._listeners.get(event)
+    if (!callbackHandlerMap.has(callback))
       return
 
-    const handlerID = fnMap.get(callback)
+    const handlerID = callbackHandlerMap.get(callback)
     this.disconnect(handlerID)
-    fnMap.delete(callback)
+    callbackHandlerMap.delete(callback)
     return this
   }
 
@@ -87,7 +87,7 @@ function extendBaseClass(BaseClass) {
     if (!this._listeners.has(event))
       this._listeners.set(event, new WeakMap())
 
-    const fnMap = this._listeners.get(event)
+    const callbackHandlerMap = this._listeners.get(event)
 
     const newCallback = (...args) => {
       this.off(event, callback)
@@ -101,7 +101,7 @@ function extendBaseClass(BaseClass) {
     // Key the listener map by the user's original callback so that it can be
     // cancelled with off(event, callback), even though the connected handler
     // is the wrapper.
-    fnMap.set(callback, handlerID)
+    callbackHandlerMap.set(callback, handlerID)
     return this
   }
 
@@ -127,7 +127,7 @@ function define(object, description) {
 }
 
 function getFunctionDescription(info) {
-  const fn = internal.MakeFunction(info);
+  const wrappedFunction = internal.MakeFunction(info);
   const name = getInfoName(info);
   const flags = GI.function_info_get_flags(info);
   const isMethod =
@@ -139,7 +139,7 @@ function getFunctionDescription(info) {
     property: {
       configurable: true,
       writable: true,
-      value: fn
+      value: wrappedFunction
     }
   }
 }

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -17,11 +17,11 @@ function def(obj, name, data) {
     });
 }
 
-const obj          = ()          => Object.create(null);
-const name         = (info)      => GI.BaseInfo_get_name.call(info);
-const namespace    = (info)      => GI.BaseInfo_get_namespace.call(info);
+const createEmptyObject          = ()          => Object.create(null);
+const getInfoName         = (info)      => GI.BaseInfo_get_name.call(info);
+const getInfoNamespace    = (info)      => GI.BaseInfo_get_namespace.call(info);
 const getInfoType  = (info)      => GI.BaseInfo_get_type.call(info);
-const tag          = (type_info) => GI.type_info_get_tag(type_info);
+const getTypeTag          = (type_info) => GI.type_info_get_tag(type_info);
 const isDeprecated = (info)      => GI.BaseInfo_is_deprecated.call(info)
 
 const infoTypeString   = (type_info) => {
@@ -30,7 +30,7 @@ const infoTypeString   = (type_info) => {
         return GI.type_tag_to_string(tag)
     const interfaceInfo = GI.type_info_get_interface(type_info)
     const interfaceInfoType = getInfoType(interfaceInfo)
-    return GI.info_type_to_string(interfaceInfoType) + '.' + name(interfaceInfo)
+    return GI.info_type_to_string(interfaceInfoType) + '.' + getInfoName(interfaceInfo)
 }
 
 function gtype(info) {
@@ -69,7 +69,7 @@ function findBoxedConstructor(info, parent) {
         if (!result) {
             for (let i = 0; i < n_methods; i++) {
                 const fn_info = GI.union_info_get_method (info, i);
-                if (name(fn_info) === 'new') {
+                if (getInfoName(fn_info) === 'new') {
                     result = fn_info;
                     break;
                 }
@@ -100,7 +100,7 @@ function findBoxedConstructor(info, parent) {
         if (!result) {
             for (let i = 0; i < n_methods; i++) {
                 const fn_info = GI.struct_info_get_method (info, i);
-                if (name(fn_info) === 'new') {
+                if (getInfoName(fn_info) === 'new') {
                     result = fn_info;
                     break;
                 }
@@ -127,12 +127,12 @@ function findBoxedConstructor(info, parent) {
 function BaseInfo(info, parent) {
     def(this, '_info', info);
     def(this, '_type', getInfoType(info)); // info_type
-    def(this, '_ns',   namespace(info));
+    def(this, '_ns',   getInfoNamespace(info));
 
     this.infoType = GI.info_type_to_string(this._type);
 
     if (this._type != GI.InfoType.TYPE)
-        this.name = name(info);
+        this.name = getInfoName(info);
 
     if (parent)
         this.parent = parent
@@ -146,7 +146,7 @@ function BaseInfo(info, parent) {
 function TypeInfo(info) {
     BaseInfo.call(this, info)
 
-    def(this, '_tag',  tag(info));
+    def(this, '_tag',  getTypeTag(info));
 
     if (this._tag == GI.TypeTag.ARRAY) {
         this.type = infoTypeString(info);
@@ -210,7 +210,7 @@ function PropInfo(info, parent) {
     BaseInfo.call(this, info, parent)
     def(this, '_flags', GI.property_info_get_flags(info));
     def(this, '_typeInfo', GI.property_info_get_type(info));
-    def(this, '_tag', tag(this._typeInfo));
+    def(this, '_tag', getTypeTag(this._typeInfo));
 
     this.type = infoTypeString(this._typeInfo);
 
@@ -224,7 +224,7 @@ function FieldInfo(info, parent) {
     def(this, '_offset', GI.field_info_get_offset(info));
     def(this, '_size', GI.field_info_get_size(info));
     def(this, '_typeInfo', GI.field_info_get_type(info));
-    def(this, '_tag', tag(this._typeInfo));
+    def(this, '_tag', getTypeTag(this._typeInfo));
 
     this.type = infoTypeString(this._typeInfo);
 
@@ -246,20 +246,20 @@ function StructInfo(info, parent) {
     this.is_foreign = GI.struct_info_is_foreign(this._info)
 
     this.constructor = findBoxedConstructor(info, this)
-    this.methods = obj();
-    this.fields  = obj();
+    this.methods = createEmptyObject();
+    this.fields  = createEmptyObject();
 
     const n_methods = GI.struct_info_get_n_methods(info);
     for (let i = 0; i < n_methods; i++) {
         const method = GI.struct_info_get_method(info, i);
-        const methodName = name(method);
+        const methodName = getInfoName(method);
         this.methods[methodName] = new FunctionInfo(method, this);
     }
 
     const n_fields = GI.struct_info_get_n_fields(info);
     for (let i = 0; i < n_fields; i++) {
         const field = GI.struct_info_get_field(info, i);
-        const fieldName = name(field);
+        const fieldName = getInfoName(field);
         this.fields[fieldName] = new FieldInfo(field, this);
     }
 }
@@ -282,14 +282,14 @@ function UnionInfo(info, parent) {
     const n_methods = GI.union_info_get_n_methods(info);
     for (let i = 0; i < n_methods; i++) {
         const method = GI.union_info_get_method(info, i);
-        const methodName = name(method);
+        const methodName = getInfoName(method);
         this.methods[methodName] = new FunctionInfo(method, this);
     }
 
     const n_fields = GI.union_info_get_n_fields(info);
     for (let i = 0; i < n_fields; i++) {
         const field = GI.union_info_get_field(info, i);
-        const fieldName = name(field);
+        const fieldName = getInfoName(field);
         this.fields[fieldName] = new FieldInfo(field, this);
         if (is_discriminated) {
             const d = GI.union_info_get_discriminator(info, i);
@@ -302,20 +302,20 @@ function EnumInfo(info, parent) {
     BaseInfo.call(this, info, parent)
     this.gtype = gtype(info);
 
-    this.values  = obj();
-    this.methods = obj();
+    this.values  = createEmptyObject();
+    this.methods = createEmptyObject();
 
     const n_values = GI.enum_info_get_n_values(info);
     for (let i = 0; i < n_values; i++) {
         const valueInfo  = GI.enum_info_get_value(info, i);
-        const valueName  = name(valueInfo);
+        const valueName  = getInfoName(valueInfo);
         this.values[valueName] = new ValueInfo(valueInfo, this);
     }
 
     const n_methods = GI.enum_info_get_n_methods(info);
     for (let i = 0; i < n_methods; i++) {
         const method = GI.enum_info_get_method(info, i);
-        const methodName = name(method);
+        const methodName = getInfoName(method);
         this.methods[methodName] = new FunctionInfo(method, this);
     }
 }
@@ -326,52 +326,52 @@ function InterfaceInfo(info, parent) {
     const structInfo = GI.interface_info_get_iface_struct(info)
     if (structInfo !== null)
         this.iface_struct = new StructInfo(structInfo, this);
-    this.prerequisites = obj();
-    this.properties    = obj();
-    this.methods       = obj();
-    this.signals       = obj();
-    this.vfuncs        = obj();
-    this.constants     = obj();
+    this.prerequisites = createEmptyObject();
+    this.properties    = createEmptyObject();
+    this.methods       = createEmptyObject();
+    this.signals       = createEmptyObject();
+    this.vfuncs        = createEmptyObject();
+    this.constants     = createEmptyObject();
 
     const n_prerequisites = GI.interface_info_get_n_prerequisites(info);
     for (let i = 0; i < n_prerequisites; i++) {
         const prerequisite = GI.interface_info_get_prerequisite(info, i);
-        const prerequisiteName = name(prerequisite);
+        const prerequisiteName = getInfoName(prerequisite);
         this.prerequisites[prerequisiteName] = getInfo(prerequisite);
     }
 
     const n_properties = GI.interface_info_get_n_properties(info);
     for (let i = 0; i < n_properties; i++) {
         const property = GI.interface_info_get_property(info, i);
-        const propertyName = name(property);
+        const propertyName = getInfoName(property);
         this.properties[propertyName] = getInfo(property, this);
     }
 
     const n_methods = GI.interface_info_get_n_methods(info);
     for (let i = 0; i < n_methods; i++) {
         const method = GI.interface_info_get_method(info, i);
-        const methodName = name(method);
+        const methodName = getInfoName(method);
         this.methods[methodName] = getInfo(method, this);
     }
 
     const n_signals = GI.interface_info_get_n_signals(info);
     for (let i = 0; i < n_signals; i++) {
         const signal = GI.interface_info_get_signal(info, i);
-        const signalName = name(signal);
+        const signalName = getInfoName(signal);
         this.signals[signalName] = signal;
     }
 
     const n_vfuncs = GI.interface_info_get_n_vfuncs(info);
     for (let i = 0; i < n_vfuncs; i++) {
         const vfuncInfo = GI.interface_info_get_vfunc(info, i);
-        const vfuncName = name(vfuncInfo);
+        const vfuncName = getInfoName(vfuncInfo);
         this.vfuncs[vfuncName] = getInfo(vfuncInfo, this);
     }
 
     const n_constants = GI.interface_info_get_n_constants(info);
     for (let i = 0; i < n_constants; i++) {
         const constant = GI.interface_info_get_constant(info, i);
-        const constantName = name(constant);
+        const constantName = getInfoName(constant);
         this.constants[constantName] = getInfo(constant);
     }
 }
@@ -382,53 +382,53 @@ function ObjectInfo(info, parent) {
     const parentInfo = GI.object_info_get_parent(info)
     if (parentInfo)
         def(this, '_parent', new ObjectInfo(parentInfo, parent));
-    this.constants  = obj();
-    this.fields     = obj();
-    this.interfaces = obj();
-    this.methods    = obj();
-    this.properties = obj();
-    this.signals    = obj();
-    this.vfuncs     = obj();
+    this.constants  = createEmptyObject();
+    this.fields     = createEmptyObject();
+    this.interfaces = createEmptyObject();
+    this.methods    = createEmptyObject();
+    this.properties = createEmptyObject();
+    this.signals    = createEmptyObject();
+    this.vfuncs     = createEmptyObject();
 
     const n_properties = GI.object_info_get_n_properties(info);
     for (let i = 0; i < n_properties; i++) {
         const propertyInfo = GI.object_info_get_property(info, i);
-        const propertyName = name(propertyInfo);
+        const propertyName = getInfoName(propertyInfo);
         this.properties[propertyName] = getInfo(propertyInfo, this);
     }
 
     const n_constants = GI.object_info_get_n_constants(info);
     for (let i = 0; i < n_constants; i++) {
         const constantInfo = GI.object_info_get_constant(info, i);
-        const constantName = name(constantInfo);
+        const constantName = getInfoName(constantInfo);
         this.constants[constantName] = getInfo(constantInfo, this);
     }
 
     const n_interfaces = GI.object_info_get_n_interfaces(info);
     for (let i = 0; i < n_interfaces; i++) {
         const i_info = GI.object_info_get_interface(info, i);
-        const i_name = name(i_info);
+        const i_name = getInfoName(i_info);
         this.interfaces[i_name] = new InterfaceInfo(i_info, this);
     }
 
     const n_methods = GI.object_info_get_n_methods(info);
     for (let i = 0; i < n_methods; i++) {
         const methodInfo = GI.object_info_get_method(info, i);
-        const methodName = name(methodInfo);
+        const methodName = getInfoName(methodInfo);
         this.methods[methodName] = new FunctionInfo(methodInfo, this);
     }
 
     const n_signals = GI.object_info_get_n_signals(info);
     for (let i = 0; i < n_signals; i++) {
         const signalInfo = GI.object_info_get_signal(info, i);
-        const signalName = name(signalInfo);
+        const signalName = getInfoName(signalInfo);
         this.signals[signalName] = getInfo(signalInfo, this);
     }
 
     const n_vfuncs = GI.object_info_get_n_vfuncs(info);
     for (let i = 0; i < n_vfuncs; i++) {
         const vfuncInfo = GI.object_info_get_vfunc(info, i);
-        const vfuncName = name(vfuncInfo);
+        const vfuncName = getInfoName(vfuncInfo);
         this.vfuncs[vfuncName] = getInfo(vfuncInfo, this);
     }
 }
@@ -436,10 +436,10 @@ function ObjectInfo(info, parent) {
 function ArgInfo(info, parent) {
     BaseInfo.call(this, info, parent)
     def(this, '_typeInfo', GI.arg_info_get_type(info));
-    def(this, '_tag', tag(this._typeInfo));
+    def(this, '_tag', getTypeTag(this._typeInfo));
     this.typeName = infoTypeString(this._typeInfo);
     this.type = new TypeInfo(this._typeInfo);
-    this.name = name(info);
+    this.name = getInfoName(info);
     this.direction = GI.Direction[GI.arg_info_get_direction(info)];
     this.transfer = GI.Transfer[GI.arg_info_get_ownership_transfer(info)];
 
@@ -542,7 +542,7 @@ function parseNamespace(ns, ver) {
     for (let i = 0; i < nInfos; i++) {
         const info = GI.Repository_get_info.call(repo, ns, i);
         const baseinfo = getInfo(info, ns);
-        const basename = name(info);
+        const basename = getInfoName(info);
         module[basename] = baseinfo;
     }
     return module;

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -9,24 +9,24 @@ module.exports = {
 }
 
 
-let didStart = false
-let nextTick = process.nextTick
-let setTimeout = global.setTimeout
-let setInterval = global.setInterval
-let setImmediate = global.setImmediate
+let loopStarted = false
+let originalNextTick = process.nextTick
+let originalSetTimeout = global.setTimeout
+let originalSetInterval = global.setInterval
+let originalSetImmediate = global.setImmediate
 
 /**
  * Starts the loops integration
  */
 function start() {
-  if (didStart)
+  if (loopStarted)
     return
-  didStart = true
+  loopStarted = true
 
-  process.nextTick = wrappedLoopFunction(nextTick)
-  global.setTimeout = wrappedLoopFunction(setTimeout)
-  global.setInterval = wrappedLoopFunction(setInterval)
-  global.setImmediate = wrappedLoopFunction(setImmediate)
+  process.nextTick = wrappedLoopFunction(originalNextTick)
+  global.setTimeout = wrappedLoopFunction(originalSetTimeout)
+  global.setInterval = wrappedLoopFunction(originalSetInterval)
+  global.setImmediate = wrappedLoopFunction(originalSetImmediate)
 
   internal.StartLoop()
 }
@@ -34,9 +34,9 @@ function start() {
 
 // Helpers
 
-function wrappedLoopFunction(fn) {
+function wrappedLoopFunction(timerFunction) {
   return (callback, ...rest) => {
-    return fn(tryCallback(callback), ...rest)
+    return timerFunction(tryCallback(callback), ...rest)
   }
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,25 +21,25 @@ module.exports = {
 
 /**
  * Requires a module. Automatically loads dependencies.
- * @param {string} ns - namespace to load
+ * @param {string} namespace - namespace to load
  * @param {string} [version=null] - version to load (null for latest)
  * @returns {Object} the loaded module
  */
-function giRequire(ns, version) {
-  if (moduleCache[ns])
-    return moduleCache[ns]
+function giRequire(namespace, version) {
+  if (moduleCache[namespace])
+    return moduleCache[namespace]
 
-  const module = moduleCache[ns] = Object.create(null)
+  const module = moduleCache[namespace] = Object.create(null)
 
   const repo = GI.Repository_get_default()
-  GI.Repository_require.call(repo, ns, version || null, 0)
-  version = version || GI.Repository_get_version.call(repo, ns)
+  GI.Repository_require.call(repo, namespace, version || null, 0)
+  version = version || GI.Repository_get_version.call(repo, namespace)
 
-  loadDependencies(ns, version)
+  loadDependencies(namespace, version)
 
-  const nInfos = GI.Repository_get_n_infos.call(repo, ns);
+  const nInfos = GI.Repository_get_n_infos.call(repo, namespace);
   for (let i = 0; i < nInfos; i++) {
-    const info = GI.Repository_get_info.call(repo, ns, i);
+    const info = GI.Repository_get_info.call(repo, namespace, i);
     const item = makeInfo(info);
 
     if (item !== undefined)
@@ -48,9 +48,9 @@ function giRequire(ns, version) {
 
   // Apply overrides, if present
   let override
-  try { override = require.resolve(`./overrides/${[ns, version].join('-')}.js`) }
+  try { override = require.resolve(`./overrides/${[namespace, version].join('-')}.js`) }
   catch (e) {
-    try { override = require.resolve(`./overrides/${ns}.js`) }
+    try { override = require.resolve(`./overrides/${namespace}.js`) }
     catch (e) {}
   }
   if (override)
@@ -62,9 +62,9 @@ function giRequire(ns, version) {
 /**
  * Loads dependencies of a library
  */
-function loadDependencies(ns, version) {
+function loadDependencies(namespace, version) {
   const repo = GI.Repository_get_default()
-  const dependencies = GI.Repository_get_dependencies.call(repo, ns, version)
+  const dependencies = GI.Repository_get_dependencies.call(repo, namespace, version)
 
   dependencies.forEach(dependency => {
     const [name, version] = dependency.split('-')
@@ -75,14 +75,14 @@ function loadDependencies(ns, version) {
 /**
  * Check if module version is loaded
  */
-function isLoaded(ns, version) {
-  const namespace = moduleCache[ns] || (moduleCache[ns] = Object.create(null));
+function isLoaded(namespace, version) {
+  const cache = moduleCache[namespace] || (moduleCache[namespace] = Object.create(null));
   version = version || null;
 
-  if (namespace[version])
+  if (cache[version])
     return true;
 
-  if (version == null && namespace.length > 0)
+  if (version == null && cache.length > 0)
     return true;
 
   return false;

--- a/lib/register-class.js
+++ b/lib/register-class.js
@@ -13,16 +13,16 @@ module.exports = registerClass
 
 /**
  * Create a new GObject type
- * @param {Class} klass - The class to register
- * @param {string} [klass.GTypeName] - The name of the GType (klass.name by default)
+ * @param {Class} classDefinition - The class to register
+ * @param {string} [classDefinition.GTypeName] - The name of the GType (classDefinition.name by default)
  */
-function registerClass(klass) {
-  const parent = Object.getPrototypeOf(klass.prototype).constructor
+function registerClass(classDefinition) {
+  const parent = Object.getPrototypeOf(classDefinition.prototype).constructor
 
-  if (!(klass.prototype instanceof GObject.Object))
+  if (!(classDefinition.prototype instanceof GObject.Object))
     throw new Error(`Invalid base class (${parent.name})`)
 
-  const name = createGTypeName(klass)
+  const name = createGTypeName(classDefinition)
   const gtype = GObject.typeFromName(name)
   const parentName = getGTypeName(parent)
   const parentGtype = GObject.typeFromName(parentName)
@@ -34,26 +34,26 @@ function registerClass(klass) {
     throw new Error(`Parent class not registered: ${parent.name}`)
 
   // Register the class with the type system
-  const klassGtype = internal.RegisterClass(name, klass, parentName, parent)
+  const klassGtype = internal.RegisterClass(name, classDefinition, parentName, parent)
 
   // Setup our class as the native ones are done
-  klass.prototype.__gtype__ = klassGtype
+  classDefinition.prototype.__gtype__ = klassGtype
 
   // Setup virtual functions
-  setupVirtualFunctions(klass, klassGtype, parentGtype)
+  setupVirtualFunctions(classDefinition, klassGtype, parentGtype)
 }
 
 // Helpers
 
-function setupVirtualFunctions(klass, klassGtype, parentGtype) {
+function setupVirtualFunctions(classDefinition, klassGtype, parentGtype) {
   const parentInfo = findInfoByGtype(parentGtype)
   if (!parentInfo)
     throw new Error(`Could not find GIR data in inheritance chain`)
 
-  Object.getOwnPropertyNames(klass.prototype).forEach(key => {
+  Object.getOwnPropertyNames(classDefinition.prototype).forEach(key => {
     if (key === 'constructor')
       return
-    if (typeof klass.prototype[key] !== 'function')
+    if (typeof classDefinition.prototype[key] !== 'function')
       return
 
     const nativeName = snakeCase(key)
@@ -66,7 +66,7 @@ function setupVirtualFunctions(klass, klassGtype, parentGtype) {
       vfuncInfo,
       klassGtype,
       nativeName,
-      klass.prototype[key]
+      classDefinition.prototype[key]
     )
   })
 }
@@ -149,9 +149,9 @@ function findInfoByGtype(gtype) {
 
 
 
-function getGTypeName(klass) {
+function getGTypeName(classDefinition) {
   const name =
-    klass.hasOwnProperty('GTypeName') ? klass.GTypeName : klass.name
+    classDefinition.hasOwnProperty('GTypeName') ? classDefinition.GTypeName : classDefinition.name
 
   if (name) {
     const sanitized = sanitizeGType(name);
@@ -164,13 +164,13 @@ function getGTypeName(klass) {
 }
 
 let nextId = 1
-function createGTypeName(klass) {
-  const name = getGTypeName(klass)
+function createGTypeName(classDefinition) {
+  const name = getGTypeName(classDefinition)
   if (name)
     return name
 
   const newName = `Anonymous${nextId++}`
-  klass.name = newName
+  classDefinition.name = newName
   return sanitizeGType(newName)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,9 +7,9 @@ module.exports = {
   countUtf8Bytes,
 }
 
-function override(target, fnName, modFn) {
-  const fn = target.prototype[fnName]
-  target.prototype[fnName] = modFn(fn)
+function override(target, methodName, modifierFunction) {
+  const fn = target.prototype[methodName]
+  target.prototype[methodName] = modifierFunction(fn)
 }
 
 function countUtf8Bytes(s){


### PR DESCRIPTION
## Summary

A focused, **behavior-neutral** semantic rename pass over the `lib/` JS layer for readability. No casing changes (PascalCase↔camelCase out of scope), no structural moves — just clearer names for *durable* identifiers (functions, parameters, struct fields, module bindings). Local/loop variables are intentionally left alone.

## Renames

| File | Change |
|------|--------|
| `bootstrap.js` | `fnMap` → `callbackHandlerMap`; `getFunctionDescription`'s `fn` → `wrappedFunction` |
| `loop.js` | `didStart` → `loopStarted`; saved globals `nextTick`/`setTimeout`/`setInterval`/`setImmediate` → `original*` (they previously shadowed the globals); `wrappedLoopFunction`'s `fn` → `timerFunction` |
| `module.js` | `require`/`loadDependencies`/`isLoaded` param `ns` → `namespace` (the `isLoaded` inner cache local was renamed to `cache` to avoid the resulting collision) |
| `register-class.js` | public `registerClass`'s `klass` → `classDefinition` |
| `utils.js` | `override`'s `fnName`/`modFn` → `methodName`/`modifierFunction` |
| `inspect.js` | helper fns `obj`/`name`/`namespace`/`tag` → `createEmptyObject`/`getInfoName`/`getInfoNamespace`/`getTypeTag` (renames are call-site-scoped, so `def()` params and local `tag`/`name` shadows are untouched) |

Diff is symmetric (112 insertions / 112 deletions) — consistent with a pure rename.

> Note: an earlier revision of this PR also renamed `GI` → `giRepository`; that change has been reverted at the author's request.

## Verification

`npm test` gives **identical results before and after** this change: `72 passing, 1 failing`. The single failure is `require.js` (`Peas` / `PeasGtk`) — a **pre-existing environmental** conflict where system libpeas is built against GIRepository-3.0 while node-gtk loads GIRepository-2.0 (`"Requiring namespace 'GIRepository' version '3.0', but '2.0' is already loaded"`). It reproduces on pristine `master` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)