### PR TITLE
fix: access union fields at offset 0 to avoid OOB read/write (#376)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,6 @@ jobs:
         run: |
           npx mocha                                 \
                     --skip=callback                 \
-                    --skip=union__fields            \
                     tests/__run__.js
 
   build:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -48,12 +48,10 @@ function npm_test() {
         npm run build:test-fixtures || true;
         npx mocha                                 \
                   --skip=callback                 \
-                  --skip=union__fields            \
                   tests/__run__.js
     else
         xvfb-run -a npm test --                   \
-                  --skip=callback                 \
-                  --skip=union__fields;
+                  --skip=callback;
     fi;
 }
 

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -208,6 +208,49 @@ NAN_METHOD(ObjectPropertySetter) {
         RETURN(success.ToLocalChecked());
 }
 
+// All members of a C union live at offset 0. Some GLib versions (the
+// regression fixed in 2.86.1 — glib#3745) emit a bogus 0xffff offset for union
+// field members in the compiled typelib, so g_field_info_get_field /
+// g_field_info_set_field would read/write far out of bounds and crash. Detect
+// union fields so they can be accessed directly at offset 0 instead (#376).
+static bool FieldIsInUnion (GIFieldInfo *field) {
+    GIBaseInfo *container = g_base_info_get_container (field);
+    return container != NULL
+        && g_base_info_get_type (container) == GI_INFO_TYPE_UNION;
+}
+
+// Whether a field type is a simple (non-pointer) C value that can be read or
+// written by copying its bytes — mirrors what g_field_info_get/set_field
+// accept. Pointer-backed types (strings, nested structs, arrays, ...) return
+// false and are rejected, as before.
+static bool IsSimpleFieldType (GITypeInfo *type_info) {
+    switch (g_type_info_get_tag (type_info)) {
+        case GI_TYPE_TAG_BOOLEAN:
+        case GI_TYPE_TAG_INT8:
+        case GI_TYPE_TAG_UINT8:
+        case GI_TYPE_TAG_INT16:
+        case GI_TYPE_TAG_UINT16:
+        case GI_TYPE_TAG_INT32:
+        case GI_TYPE_TAG_UINT32:
+        case GI_TYPE_TAG_INT64:
+        case GI_TYPE_TAG_UINT64:
+        case GI_TYPE_TAG_FLOAT:
+        case GI_TYPE_TAG_DOUBLE:
+        case GI_TYPE_TAG_UNICHAR:
+        case GI_TYPE_TAG_GTYPE:
+            return true;
+        case GI_TYPE_TAG_INTERFACE: {
+            GIBaseInfo *iface = g_type_info_get_interface (type_info);
+            GIInfoType  itype = g_base_info_get_type (iface);
+            bool simple = (itype == GI_INFO_TYPE_ENUM || itype == GI_INFO_TYPE_FLAGS);
+            g_base_info_unref (iface);
+            return simple;
+        }
+        default:
+            return false;
+    }
+}
+
 NAN_METHOD(StructFieldSetter) {
     Local<Object> boxedWrapper = info[0].As<Object>();
     Local<Object> fieldInfo    = info[1].As<Object>();
@@ -230,6 +273,17 @@ NAN_METHOD(StructFieldSetter) {
         g_free(message);
 
         RETURN (Nan::Undefined());
+
+    } else if (FieldIsInUnion(field)) {
+
+        // Union members are at offset 0; write directly to avoid the bogus
+        // introspected offset (glib#3745, #376).
+        if (IsSimpleFieldType(field_type)) {
+            memcpy(boxed, &arg, GNodeJS::GetTypeSize(field_type));
+        } else {
+            Nan::ThrowError("Unable to set field (complex types not allowed)");
+            RETURN (Nan::Undefined());
+        }
 
     } else {
 
@@ -285,6 +339,19 @@ NAN_METHOD(StructFieldGetter) {
     GIArgument value;
     GNodeJS::ResourceOwnership ownership = GNodeJS::kCopy;
     BaseInfo typeInfo = g_field_info_get_type(*fieldInfo);
+
+    if (FieldIsInUnion(*fieldInfo)) {
+        // Union members are at offset 0; read directly to avoid the bogus
+        // introspected offset (glib#3745, #376).
+        if (!IsSimpleFieldType(*typeInfo)) {
+            Nan::ThrowError("Converting non-primitive fields is not allowed");
+            return;
+        }
+        memset(&value, 0, sizeof(value));
+        memcpy(&value, boxed, GNodeJS::GetTypeSize(*typeInfo));
+        RETURN(GNodeJS::GIArgumentToV8(*typeInfo, &value, -1, ownership));
+        return;
+    }
 
     if (!g_field_info_get_field(*fieldInfo, boxed, &value)) {
         /* If g_field_info_get_field() failed, this is a non-primitive type */


### PR DESCRIPTION
## Summary

Fixes #376. A GLib **regression** (glib#3745, security-labelled, fixed in **2.86.1**) emits a bogus `0xffff` offset for union field members in compiled typelibs. `g_field_info_get_field` / `g_field_info_set_field` then read/write ~64 KB out of bounds → segfault. This is why `tests/union__fields.js` was excluded from CI via `--skip=union__fields`.

node-gtk still supports GLib versions in the affected range, and this is a memory-safety bug, so guard against it directly rather than relying on the runtime GLib being patched.

### Fix
All members of a C union are at **offset 0** by definition. For a field whose container is a union, read/write the value at offset 0 directly instead of trusting the introspected offset. Only simple (non-pointer) C field types are handled this way; complex types are rejected with the same error as before. Struct fields are unchanged (they still use `g_field_info_get/set_field`).

Also drops `--skip=union__fields` from CI (`.github/workflows/main.yaml` and `scripts/ci.sh`) so `tests/union__fields.js` runs on every platform again.

## Test

`tests/union__fields.js` (`GLib.TokenValue`) now passes — zero-init, get/set of `vInt64 = MAX_SAFE_INTEGER`, `vInt = 257` → `vChar === 1` overlap, and complex-type (`vString`) rejection — verified 5/5 with no abort. Full struct/union/boxed/marshalling/function-call suite: 32 pass, 0 fail (struct field access unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)