### PR TITLE
feat: accept camelCase constructor property names (#320)

### DIFF
--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -59,7 +59,10 @@ static GObject* CreateGObjectFromObject(GType gtype, Local<Value> object) {
 
     for (int i = 0; i < n_properties; i++) {
         Local<String> name = TO_STRING (Nan::Get(properties, i).ToLocalChecked());
-        const char *name_string = g_strdup (*Nan::Utf8String(name));
+        // Accept camelCase property names (e.g. iconName) in addition to
+        // dashed/underscored ones; GObject canonicalizes '_' to '-' but not
+        // camelCase, so convert here (#320).
+        char *name_string = Util::ToDashed (*Nan::Utf8String(name));
         Local<Value> value = Nan::Get(property_hash, name).ToLocalChecked();
 
         auto value_spec = g_object_class_find_property (G_OBJECT_CLASS (klass), name_string);

--- a/tests/object__construct_props.js
+++ b/tests/object__construct_props.js
@@ -1,0 +1,26 @@
+/*
+ * object__construct_props.js
+ *
+ * Construct-time properties passed in the initializer object may be written in
+ * camelCase (idiomatic JS), underscored, or dashed — all are normalized to the
+ * GObject canonical (dashed) property name (#320).
+ */
+
+const gi = require('../lib')
+const Gtk = gi.require('Gtk', '3.0')
+const { describe, it, expect, mustThrow } = require('./__common__.js')
+
+Gtk.init([])
+
+describe('construct props', () => {
+  it('accepts camelCase / underscore / dashed names (#320)', () => {
+    expect(new Gtk.Image({ iconName: 'folder' }).iconName, 'folder')
+    expect(new Gtk.Image({ icon_name: 'edit' }).iconName, 'edit')
+    expect(new Gtk.Image({ 'icon-name': 'go-up' }).iconName, 'go-up')
+  })
+
+  it('still rejects unknown names', mustThrow(
+    'Invalid property name: does-not-exist',
+    () => { new Gtk.Image({ doesNotExist: 1 }) }
+  ))
+})


### PR DESCRIPTION
## Summary

Fixes #320. Construct-time properties in the initializer object (`new Gtk.Image({ ... })`) were looked up by their raw key. GObject canonicalizes `_` → `-`, so `icon_name` worked, but **camelCase** (`iconName`) — idiomatic JS, and what the generated TypeScript types use — did not, throwing `Invalid property name`.

### Fix
Normalize each initializer key with `Util::ToDashed` (the same conversion already used for property accessor getters/setters), so `iconName`, `icon_name`, and `icon-name` all resolve to the canonical `icon-name`. Unknown names still throw.

## Test

New `tests/object__construct_props.js` verifies all three spellings set the property and that an unknown name still throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)