### PR TITLE
feat: add gi.getGType() to get the GType of a class or instance (#286)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,30 @@ const module_ = require('./module.js')
 const loop = require('./loop.js')
 const registerClass = require('./register-class.js')
 
+/**
+ * Returns the GType (as a BigInt) of a GObject/boxed class, an instance of one,
+ * or a GType passed through as-is. See #286.
+ *
+ * @param {Function|object|bigint} value a class, an instance, or a GType
+ * @returns {bigint} the associated GType
+ */
+function getGType(value) {
+  if (typeof value === 'bigint')
+    return value
+
+  if (value != null) {
+    // A class: the GType lives on its prototype.
+    if (typeof value === 'function' && value.prototype != null && value.prototype.__gtype__ !== undefined)
+      return value.prototype.__gtype__
+
+    // An instance (or prototype).
+    if (value.__gtype__ !== undefined)
+      return value.__gtype__
+  }
+
+  throw new TypeError('getGType: expected a GObject/boxed class, instance, or GType')
+}
+
 /*
  * Exports
  */
@@ -20,6 +44,7 @@ module.exports = {
   ...module_,
   startLoop: loop.start,
   registerClass: registerClass,
+  getGType: getGType,
   System: internal.System,
 
   // Private API

--- a/tests/object__get_gtype.js
+++ b/tests/object__get_gtype.js
@@ -1,0 +1,35 @@
+/*
+ * object__get_gtype.js
+ *
+ * gi.getGType() returns the GType of a class, an instance, or a GType (#286).
+ */
+
+const gi = require('../lib')
+const GObject = gi.require('GObject', '2.0')
+const Gtk = gi.require('Gtk', '3.0')
+const { describe, it, expect, assert, mustThrow } = require('./__common__.js')
+
+Gtk.init([])
+
+describe('getGType', () => {
+  const win = new Gtk.Window()
+  const classGType = gi.getGType(Gtk.Window)
+
+  it('returns the same GType for a class and its instance', () => {
+    assert(typeof classGType === 'bigint', 'GType should be a BigInt')
+    expect(gi.getGType(win), classGType)
+  })
+
+  it('resolves to the correct GObject type name', () => {
+    expect(GObject.typeName(classGType), 'GtkWindow')
+  })
+
+  it('passes a GType through unchanged', () => {
+    expect(gi.getGType(classGType), classGType)
+  })
+
+  it('throws for a value with no GType', mustThrow(
+    /expected a GObject\/boxed class, instance, or GType/,
+    () => { gi.getGType({}) }
+  ))
+})


### PR DESCRIPTION
## Summary

Closes #286. Adds a public `gi.getGType(value)` helper returning the GType (as a `BigInt`) of:
- a **GObject/boxed class** (`gi.getGType(Gtk.Window)`),
- an **instance** of one (`gi.getGType(win)`), or
- a **GType** passed through as-is.

It reads the existing `__gtype__` value (already present on instances and on a class's `prototype`), giving downstream tooling (e.g. ts-for-gjs, the use case in the issue) a stable, documented way to map a class to its GType instead of reaching for the internal `__gtype__` property. Unknown values throw a `TypeError`.

JS-only; no native changes.

## Test

`tests/object__get_gtype.js`: class and instance return the same GType, it matches `GObject.typeName(...) === 'GtkWindow'`, a GType passes through unchanged, and a plain object throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)