### PR TITLE
fix: don't abort on GValue types that can't be unboxed (#389)

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -1854,7 +1854,13 @@ Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
         ERROR("Unsuported type: variant");
     } else {
-        ERROR("%s", G_VALUE_TYPE_NAME(gvalue));
+        // Don't abort the whole process on a GValue type we can't convert
+        // (e.g. GStreamer's GstValueArray / GstValueList, #389). Warn and
+        // return null so the caller stays alive.
+        g_warning("GValueToV8: unhandled GValue type '%s'; returning null. "
+                  "Please report this at https://github.com/romgrk/node-gtk/issues",
+                  G_VALUE_TYPE_NAME (gvalue));
+        return Nan::Null();
     }
 }
 

--- a/tests/object__gvalue_unhandled.js
+++ b/tests/object__gvalue_unhandled.js
@@ -1,0 +1,34 @@
+/*
+ * object__gvalue_unhandled.js
+ *
+ * Converting a GValue whose type node-gtk can't unbox (e.g. GStreamer's
+ * GstValueArray) must not abort the process; it warns and returns null (#389).
+ */
+
+const gi = require('../lib')
+const GObject = gi.require('GObject', '2.0')
+const { describe, it, expect, assert, skip } = require('./__common__.js')
+
+let Gst
+try {
+  Gst = gi.require('Gst', '1.0')
+  Gst.init([])
+} catch (e) {
+  // GStreamer not available on this platform; nothing to exercise.
+  skip()
+}
+
+describe('GValueToV8 degrades gracefully for unconvertible types (#389)', () => {
+  it('returns null instead of aborting on a GstValueArray GValue', () => {
+    const gstValueArray = GObject.typeFromName('GstValueArray')
+    assert(typeof gstValueArray === 'bigint' && gstValueArray !== 0n,
+      'GstValueArray type should be registered after Gst.init')
+
+    const value = new GObject.Value()
+    value.init(gstValueArray)
+
+    // getBoxed() -> system.convertGValue() -> GValueToV8(). Previously this
+    // hit g_assert_not_reached() and aborted the process.
+    expect(value.getBoxed(), null)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #389. `GValueToV8` ended in `ERROR(...)` → `g_assert_not_reached()` for any `GValue` type it didn't explicitly handle, which **aborts the whole process**. This is reached by GStreamer collection GValues such as `GstValueArray` — e.g. reading an element's `mix-matrix` property:

```js
const el = Gst.ElementFactory.make('audioconvert', 'ac')
el.mixMatrix   // -> g_assert_not_reached() before this change
```

### Fix
Replace the abort with a `g_warning` and `return null`, so an unconvertible value degrades gracefully instead of crashing.

Converting `GstValueArray`/`GstValueList` into actual JS arrays would require GStreamer-specific support (the type is a non-boxed fundamental, not introspectable through the generic GValue API), so that's left out of scope; this change just stops the process abort.

## Test

`tests/object__gvalue_unhandled.js` (skips if GStreamer isn't installed): initializes a `GObject.Value` of type `GstValueArray` and converts it via `getBoxed()` — previously aborted, now returns `null`. No regression in `marshalling__gvalue.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)