### PR TITLE
fix: report the original property name for an unknown construct prop (#320 follow-up)

### DIFF
--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -61,13 +61,16 @@ static GObject* CreateGObjectFromObject(GType gtype, Local<Value> object) {
         Local<String> name = TO_STRING (Nan::Get(properties, i).ToLocalChecked());
         // Accept camelCase property names (e.g. iconName) in addition to
         // dashed/underscored ones; GObject canonicalizes '_' to '-' but not
-        // camelCase, so convert here (#320).
-        char *name_string = Util::ToDashed (*Nan::Utf8String(name));
+        // camelCase, so convert here (#320). The original spelling is kept so
+        // an unknown name is reported as the user wrote it.
+        Nan::Utf8String name_original (name);
+        char *name_string = Util::ToDashed (*name_original);
         Local<Value> value = Nan::Get(property_hash, name).ToLocalChecked();
 
         auto value_spec = g_object_class_find_property (G_OBJECT_CLASS (klass), name_string);
         if (value_spec == NULL) {
-            Throw::InvalidPropertyName(name_string);
+            Throw::InvalidPropertyName(*name_original);
+            g_free(name_string);
             goto out;
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #320 (#420). The camelCase support ran every initializer key through `Util::ToDashed` before lookup — including in the "Invalid property name" error path. `ToDashed` prefixes a dash before each uppercase letter, so a non-camelCase key (e.g. an `ALL_CAPS` typo) is mangled:

```
new Gtk.TextMark({ INVALID_PROP_NAME: false })
// before: Error: Invalid property name: -i-n-v-a-l-i-d_-p-r-o-p_-n-a-m-e
// after:  Error: Invalid property name: INVALID_PROP_NAME
```

This regressed `tests/object__initialization.js`; the failing assertion runs *after* that file's `if (CI) skip()`, so #420's CI didn't catch it.

### Fix
Keep the original spelling for the error message; still use the dashed form for `g_object_class_find_property` / `g_object_new`. Also frees the dashed string on the error path.

## Test

`tests/object__initialization.js` "fails when passed invalid properties" passes again, and camelCase construct props (`tests/object__construct_props.js`) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)