### PR TITLE
feat!: marshal 64-bit integers as BigInt (#323, #149) [BREAKING — draft, do not merge]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changes to be released are kept in the unreleased section.
 
 ## Unreleased
 
+- **BREAKING**: 64-bit integers are now marshalled as `BigInt` instead of
+  `Number`, so values above `Number.MAX_SAFE_INTEGER` keep full precision
+  (#323, #149). This covers `gint64`/`guint64`, the platform-dependent
+  `glong`/`gulong`/`gsize`/`gssize` (64-bit on LP64 platforms), and `GType`.
+  Both `Number` and `BigInt` are accepted as input, so code passing values in
+  is unaffected; code reading 64-bit properties, return values, struct/union
+  fields, or signal arguments now receives a `BigInt`.
+
 ## v0.5.0
 
 - Added support for GError

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -235,7 +235,10 @@ function makeEnum(info) {
   for (let i = 0; i < nValues; i++) {
     const valueInfo = GI.enum_info_get_value(info, i);
     const valueName = getName(valueInfo).toUpperCase()
-    const value = GI.value_info_get_value(valueInfo)
+    // g_value_info_get_value returns a gint64 (-> BigInt since #323), but enum
+    // and flags members are small integers and are compared/bitwise-combined
+    // as Numbers throughout, so coerce here.
+    const value = Number(GI.value_info_get_value(valueInfo))
     Object.defineProperty(object, valueName, {
       configurable: true,
       enumerable: true,

--- a/src/value.cc
+++ b/src/value.cc
@@ -35,6 +35,21 @@ static void HashPointerToGIArgument (GIArgument *arg, GITypeInfo *type_info);
 
 static bool IsUint8Array (GITypeInfo *type_info);
 
+/* Accept both Number and BigInt for 64-bit / platform-dependent integer
+ * holders. Reading those types yields a BigInt (#323, #149), so a value
+ * round-tripped through JS arrives back here as a BigInt. */
+static gint64 V8ToInt64 (Local<Value> value) {
+    if (value->IsBigInt())
+        return value.As<v8::BigInt>()->Int64Value();
+    return Nan::To<int64_t> (value).ToChecked();
+}
+
+static guint64 V8ToUint64 (Local<Value> value) {
+    if (value->IsBigInt())
+        return value.As<v8::BigInt>()->Uint64Value();
+    return (guint64) Nan::To<int64_t> (value).ToChecked();
+}
+
 
 Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length, ResourceOwnership ownership) {
     GITypeTag type_tag = g_type_info_get_tag (type_info);
@@ -61,12 +76,13 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
     case GI_TYPE_TAG_DOUBLE:
         return New<Number> (arg->v_double);
 
-    /* For 64-bit integer types, use a float. When JS and V8 adopt
-     * bigger sized integer types, start using those instead. */
+    /* 64-bit integers are returned as BigInt so values above
+     * Number.MAX_SAFE_INTEGER keep full precision (#323, #149). The IN side
+     * accepts both Number and BigInt. */
     case GI_TYPE_TAG_INT64:
-        return New<Number> (arg->v_int64);
+        return v8::BigInt::New (Isolate::GetCurrent(), arg->v_int64);
     case GI_TYPE_TAG_UINT64:
-        return New<Number> (arg->v_uint64);
+        return v8::BigInt::NewFromUnsigned (Isolate::GetCurrent(), arg->v_uint64);
 
     case GI_TYPE_TAG_GTYPE: /* c++: gsize */
         return v8::BigInt::NewFromUnsigned(Isolate::GetCurrent(), arg->v_size);
@@ -1655,19 +1671,19 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
     } else if (G_VALUE_HOLDS_UINT (gvalue)) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_LONG (gvalue)) {
-        return value->IsNumber();
+        return value->IsNumber() || value->IsBigInt();
     } else if (G_VALUE_HOLDS_ULONG (gvalue)) {
-        return value->IsNumber();
+        return value->IsNumber() || value->IsBigInt();
     } else if (G_VALUE_HOLDS_INT64 (gvalue)) {
-        return value->IsNumber();
+        return value->IsNumber() || value->IsBigInt();
     } else if (G_VALUE_HOLDS_UINT64 (gvalue)) {
-        return value->IsNumber();
+        return value->IsNumber() || value->IsBigInt();
     } else if (G_VALUE_HOLDS_FLOAT (gvalue)) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_DOUBLE (gvalue)) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_GTYPE (gvalue)) {
-        return value->IsNumber();
+        return value->IsNumber() || value->IsBigInt();
     } else if (G_VALUE_HOLDS_ENUM (gvalue)) {
         return value->IsNumber();
     } else if (G_VALUE_HOLDS_FLAGS (gvalue)) {
@@ -1722,19 +1738,19 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership)
     } else if (G_VALUE_HOLDS_UINT (gvalue)) {
         g_value_set_uint (gvalue, Nan::To<uint32_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_LONG (gvalue)) {
-        g_value_set_long (gvalue, Nan::To<int64_t> (value).ToChecked());
+        g_value_set_long (gvalue, V8ToInt64 (value));
     } else if (G_VALUE_HOLDS_ULONG (gvalue)) {
-        g_value_set_ulong (gvalue, Nan::To<int64_t> (value).ToChecked());
+        g_value_set_ulong (gvalue, V8ToUint64 (value));
     } else if (G_VALUE_HOLDS_INT64 (gvalue)) {
-        g_value_set_int64 (gvalue, Nan::To<int64_t> (value).ToChecked());
+        g_value_set_int64 (gvalue, V8ToInt64 (value));
     } else if (G_VALUE_HOLDS_UINT64 (gvalue)) {
-        g_value_set_uint64 (gvalue, Nan::To<int64_t> (value).ToChecked());
+        g_value_set_uint64 (gvalue, V8ToUint64 (value));
     } else if (G_VALUE_HOLDS_FLOAT (gvalue)) {
         g_value_set_float (gvalue, Nan::To<double> (value).ToChecked());
     } else if (G_VALUE_HOLDS_DOUBLE (gvalue)) {
         g_value_set_double (gvalue, Nan::To<double> (value).ToChecked());
     } else if (G_VALUE_HOLDS_GTYPE (gvalue)) {
-        g_value_set_gtype (gvalue, Nan::To<int64_t> (value).ToChecked());
+        g_value_set_gtype (gvalue, V8ToUint64 (value));
     } else if (G_VALUE_HOLDS_ENUM (gvalue)) {
         g_value_set_enum (gvalue, Nan::To<int32_t> (value).ToChecked());
     } else if (G_VALUE_HOLDS_FLAGS (gvalue)) {
@@ -1800,19 +1816,23 @@ Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
     } else if (G_VALUE_HOLDS_UINT (gvalue)) {
         return New<v8::Uint32>(g_value_get_uint (gvalue));
     } else if (G_VALUE_HOLDS_LONG (gvalue)) {
-        return New<Number>(g_value_get_long (gvalue));
+        /* glong/gulong are platform-dependent (64-bit on LP64), so marshal as
+         * BigInt for full precision and consistent behavior (#323, #149). */
+        return v8::BigInt::New(Isolate::GetCurrent(), g_value_get_long (gvalue));
     } else if (G_VALUE_HOLDS_ULONG (gvalue)) {
-        return New<Number>(g_value_get_ulong (gvalue));
+        return v8::BigInt::NewFromUnsigned(Isolate::GetCurrent(), g_value_get_ulong (gvalue));
     } else if (G_VALUE_HOLDS_INT64 (gvalue)) {
-        return New<Number>(g_value_get_int64 (gvalue));
+        return v8::BigInt::New(Isolate::GetCurrent(), g_value_get_int64 (gvalue));
     } else if (G_VALUE_HOLDS_UINT64 (gvalue)) {
-        return New<Number>(g_value_get_uint64 (gvalue));
+        return v8::BigInt::NewFromUnsigned(Isolate::GetCurrent(), g_value_get_uint64 (gvalue));
     } else if (G_VALUE_HOLDS_FLOAT (gvalue)) {
         return New<Number>(g_value_get_float (gvalue));
     } else if (G_VALUE_HOLDS_DOUBLE (gvalue)) {
         return New<Number>(g_value_get_double (gvalue));
     } else if (G_VALUE_HOLDS_GTYPE (gvalue)) {
-        return New<Number>(g_value_get_gtype (gvalue));
+        // A GType is a gsize; marshal as BigInt to match the GIArgument path
+        // and gi.getGType() (#323, #149).
+        return v8::BigInt::NewFromUnsigned(Isolate::GetCurrent(), g_value_get_gtype (gvalue));
     } else if (G_VALUE_HOLDS_ENUM (gvalue)) {
         return New<Integer>(g_value_get_enum (gvalue));
     } else if (G_VALUE_HOLDS_FLAGS (gvalue)) {

--- a/tests/conversion__gvalue_uint64.js
+++ b/tests/conversion__gvalue_uint64.js
@@ -2,9 +2,9 @@
  * conversion__gvalue_uint64.js
  *
  * Regression test: assigning a 64-bit value to a GObject property whose
- * type is guint64 (or gulong on LP64) must not truncate it to 32 bits.
- * This exercises V8ToGValue, which used Nan::To<uint32_t> for the
- * UINT64/ULONG branches.
+ * type is guint64 (or gulong on LP64) must not truncate it. 64-bit values are
+ * read back as BigInt (#323, #149), so they keep full precision past
+ * Number.MAX_SAFE_INTEGER. This exercises V8ToGValue / GValueToV8.
  */
 
 const gi = require('../lib/')
@@ -22,11 +22,14 @@ try {
 describe('GValue 64-bit property assignment', () => {
   const queue = Gst.ElementFactory.make('queue', 'queue0')
 
-  // max-size-time is a writable guint64 property (nanoseconds).
-  // Use a value above 2^32 but still an exact JS integer (< 2^53).
-  const value = 5000000000 // 2^32 == 4294967296
+  // max-size-time is a writable guint64 property (nanoseconds). A Number above
+  // 2^32 is accepted on the way in and read back as a BigInt.
+  queue.maxSizeTime = 5000000000 // 2^32 == 4294967296
+  expect(queue.maxSizeTime, 5000000000n)
 
-  queue.maxSizeTime = value
-
-  expect(queue.maxSizeTime, value)
+  // A value above Number.MAX_SAFE_INTEGER round-trips exactly via BigInt;
+  // this would have lost precision when marshalled through a Number.
+  const huge = 9007199254740993n // 2^53 + 1
+  queue.maxSizeTime = huge
+  expect(queue.maxSizeTime, huge)
 })

--- a/tests/marshalling__bytes.js
+++ b/tests/marshalling__bytes.js
@@ -36,7 +36,9 @@ describe('bytearray full inout (-> [h,e,l,0,255])', () => {
 
 describe('gbytes full return', () => {
   const bytes = m.gbytesFullReturn()
-  assert(bytes.getSize() === 4, `gbytes size should be 4, got ${bytes.getSize()}`)
+  // g_bytes_get_size returns a gsize, which is 64-bit on LP64 and marshalled
+  // as BigInt (#323, #149).
+  assert(bytes.getSize() === 4n, `gbytes size should be 4, got ${bytes.getSize()}`)
 })
 
 describe('gbytes none in', () => {

--- a/tests/marshalling__callback.js
+++ b/tests/marshalling__callback.js
@@ -9,6 +9,9 @@
  * the callback also has a return value it comes first ([retval, ...outs]). The
  * caller-side function returns a single unwrapped value when there is exactly
  * one result, or an array when there are several.
+ *
+ * The glong return value / out params come back as BigInt (#323, #149); the
+ * JS callback may still produce a plain Number for them.
  */
 
 const { describe, expect } = require('./__common__.js')
@@ -17,7 +20,7 @@ const { requireGIMarshallingTests } = require('./__gi-fixtures__.js')
 const m = requireGIMarshallingTests()
 
 describe('callback return value only', () => {
-  expect(m.callbackReturnValueOnly(() => 42), 42)
+  expect(m.callbackReturnValueOnly(() => 42), 42n)
 })
 
 describe('callback one out parameter', () => {
@@ -29,11 +32,11 @@ describe('callback multiple out parameters', () => {
 })
 
 describe('callback return value and one out parameter', () => {
-  expect(m.callbackReturnValueAndOneOutParameter(() => [46, 47]), [46, 47])
+  expect(m.callbackReturnValueAndOneOutParameter(() => [46, 47]), [46n, 47n])
 })
 
 describe('callback return value and multiple out parameters', () => {
-  expect(m.callbackReturnValueAndMultipleOutParameters(() => [48, 49, 50]), [48, 49, 50])
+  expect(m.callbackReturnValueAndMultipleOutParameters(() => [48, 49, 50]), [48n, 49n, 50n])
 })
 
 describe('gclosure return (-> GClosure)', () => {

--- a/tests/marshalling__gvalue.js
+++ b/tests/marshalling__gvalue.js
@@ -33,10 +33,9 @@ describe('gvalue return/out (int 42)', () => {
   expect(m.gvalueOutCallerAllocates().getInt(), 42)
 })
 
-describe('gvalue int64 out (G_MAXINT64, with double precision loss)', () => {
-  // G_MAXINT64 (2^63 - 1) is not exactly representable as a JS double; both
-  // sides round identically, so compare against the rounded reference value.
-  expect(m.gvalueInt64Out().getInt64(), Number(2n ** 63n - 1n))
+describe('gvalue int64 out (G_MAXINT64, exact via BigInt)', () => {
+  // 64-bit integers come back as BigInt (#323), so G_MAXINT64 is exact.
+  expect(m.gvalueInt64Out().getInt64(), 2n ** 63n - 1n)
 })
 
 describe('gvalue int64 in (G_MAXINT64)', () => {
@@ -44,6 +43,29 @@ describe('gvalue int64 in (G_MAXINT64)', () => {
   v.init(GObject.TYPE_INT64)
   v.setInt64(9223372036854775807n)
   m.gvalueInt64In(v)
+})
+
+describe('gvalue platform-dependent long/ulong (BigInt, exact)', () => {
+  // glong/gulong are 64-bit on LP64 platforms, so they are marshalled as
+  // BigInt and keep full precision past Number.MAX_SAFE_INTEGER (#323, #149).
+  const maxLong = 2n ** 63n - 1n
+  const maxUlong = 2n ** 64n - 1n
+
+  const l = new GObject.Value()
+  l.init(GObject.TYPE_LONG)
+  l.setLong(maxLong)
+  expect(l.getLong(), maxLong)
+
+  const ul = new GObject.Value()
+  ul.init(GObject.TYPE_ULONG)
+  ul.setUlong(maxUlong)
+  expect(ul.getUlong(), maxUlong)
+
+  // A plain Number is still accepted on the IN side.
+  const n = new GObject.Value()
+  n.init(GObject.TYPE_LONG)
+  n.setLong(123)
+  expect(n.getLong(), 123n)
 })
 
 describe('gvalue in (int 42)', () => {

--- a/tests/marshalling__integer.js
+++ b/tests/marshalling__integer.js
@@ -8,11 +8,9 @@
  * value, so we feed them the library's own `*ReturnMax`/`*ReturnMin` values:
  * this keeps the test self-consistent and avoids hardcoding bound literals.
  *
- * 64-bit widths (long, int64, ssize, ...) round-trip through a JS double and
- * lose precision past Number.MAX_SAFE_INTEGER, so their `in`/`inout` variants
- * are skipped here (feeding back a lossy value would abort the process). Their
- * `return`/`out` values are still checked, including the documented precision
- * limitation.
+ * 64-bit widths (long, int64, ssize, ...) are marshalled as BigInt (#323), so
+ * they keep full precision and round-trip exactly in every direction. Narrower
+ * widths are plain Numbers.
  */
 
 const { describe, it, expect, assert } = require('./__common__.js')
@@ -33,7 +31,8 @@ WIDTHS.forEach(w => {
 
   describe(`${w} return/out`, () => {
     const max = returnMax()
-    assert(typeof max === 'number', `${w}ReturnMax should be a number`)
+    assert(typeof max === 'number' || typeof max === 'bigint',
+      `${w}ReturnMax should be a number or bigint`)
 
     if (m[w + 'OutMax'])
       expect(m[w + 'OutMax'](), max)
@@ -42,11 +41,13 @@ WIDTHS.forEach(w => {
   })
 
   const max = returnMax()
-  const safe = Number.isSafeInteger(max)
+  // 64-bit widths come back as BigInt and round-trip exactly; narrower widths
+  // are Numbers within the safe-integer range.
+  const exact = typeof max === 'bigint' || Number.isSafeInteger(max)
 
-  it(`${w} in/inout (safe-integer only)`, () => {
-    if (!safe)
-      return // 64-bit: JS double can't represent the bound exactly
+  it(`${w} in/inout`, () => {
+    if (!exact)
+      return
 
     if (m[w + 'InMax']) m[w + 'InMax'](max)
     if (typeof returnMin === 'function' && m[w + 'InMin']) m[w + 'InMin'](returnMin())
@@ -63,4 +64,19 @@ describe('gint return/out/inout (explicit bounds)', () => {
   expect(m.intReturnMin(), -2147483648)
   expect(m.intOutMax(), 2147483647)
   expect(m.intInoutMaxMin(2147483647), -2147483648)
+})
+
+describe('platform-dependent widths are BigInt with full precision', () => {
+  // glong/gsize/gssize are 64-bit on LP64 platforms; gobject-introspection
+  // resolves them to a fixed-width tag at scan time, so on a 64-bit build they
+  // arrive as BigInt and represent G_MAXINT64 exactly (#323, #149). On a 32-bit
+  // build they would be plain Numbers, so only assert when a BigInt comes back.
+  for (const w of ['long', 'ssize']) {
+    const returnMax = m[w + 'ReturnMax']
+    if (typeof returnMax !== 'function')
+      continue
+    const max = returnMax()
+    if (typeof max === 'bigint')
+      expect(max, 2n ** 63n - 1n)
+  }
 })

--- a/tests/marshalling__struct.js
+++ b/tests/marshalling__struct.js
@@ -6,6 +6,9 @@
  * field getters (camelCased, so long_ -> long, string_ -> string, g_strv ->
  * gStrv), instance methods, construction, and array-in (both as an array of
  * struct pointers and as a contiguous array of struct values).
+ *
+ * The `long` field is a glong, which is 64-bit on LP64 platforms and so reads
+ * back as a BigInt (#323, #149). A plain Number is still accepted when writing.
  */
 
 const { describe, expect, assert } = require('./__common__.js')
@@ -15,38 +18,38 @@ const m = requireGIMarshallingTests()
 
 describe('simple struct returnv (fields + inv method)', () => {
   const s = m.simpleStructReturnv()
-  expect(s.long, 6)
+  expect(s.long, 6n)
   expect(s.int8, 7)
   s.inv() // g_asserts long == 6 && int8 == 7
 })
 
 describe('simple struct construction', () => {
   const s = new m.SimpleStruct({ long: 6, int8: 7 })
-  expect(s.long, 6)
+  expect(s.long, 6n)
   expect(s.int8, 7)
   s.inv()
 })
 
 describe('pointer struct returnv (long == 42)', () => {
   const s = m.pointerStructReturnv()
-  expect(s.long, 42)
+  expect(s.long, 42n)
   s.inv()
 })
 
 describe('boxed struct returnv (long/string/gStrv)', () => {
   const s = m.boxedStructReturnv()
-  expect(s.long, 42)
+  expect(s.long, 42n)
   expect(s.string, 'hello')
   expect(s.gStrv, ['0', '1', '2'])
   s.inv()
 })
 
 describe('boxed struct out (long == 42)', () => {
-  expect(m.boxedStructOut().long, 42)
+  expect(m.boxedStructOut().long, 42n)
 })
 
 describe('boxed struct inout (long 42 -> 0)', () => {
-  expect(m.boxedStructInout(m.boxedStructReturnv()).long, 0)
+  expect(m.boxedStructInout(m.boxedStructReturnv()).long, 0n)
 })
 
 describe('boxed struct out uninitialized (returns false)', () => {
@@ -55,7 +58,7 @@ describe('boxed struct out uninitialized (returns false)', () => {
 })
 
 describe('union returnv (long == 42)', () => {
-  expect(m.unionReturnv().long, 42)
+  expect(m.unionReturnv().long, 42n)
 })
 
 describe('array of struct pointers in (none/take)', () => {

--- a/tests/object__non-introspected.js
+++ b/tests/object__non-introspected.js
@@ -38,7 +38,7 @@ describe('create non-introspected objected', () => {
 
   it('has non-introspected properties', () => {
     expect(src.pattern, 0)
-    expect(src.timestampOffset, 0)
+    expect(src.timestampOffset, 0n) // gint64 -> BigInt (#323, #149)
     expect(src.isLive, false)
   })
 

--- a/tests/union__fields.js
+++ b/tests/union__fields.js
@@ -13,21 +13,24 @@ const tk = new GLib.TokenValue()
 
 /*
  * unions are zero initialized
+ * (vInt64 is a gint64, so it reads back as BigInt — #323, #149)
  */
 {
   const result = tk.vInt64
   console.log('Result:', result)
-  common.assert(result === 0, "union not zero initialized")
+  common.assert(result === 0n, "union not zero initialized")
 }
 
 /*
  * get/set works
+ * A Number is accepted on the way in; a gint64 reads back as BigInt, and a
+ * value above Number.MAX_SAFE_INTEGER now round-trips with full precision.
  */
 {
-  tk.vInt64 = Number.MAX_SAFE_INTEGER
+  tk.vInt64 = 2n ** 53n + 1n
   const result = tk.vInt64
   console.log('Result:', result)
-  common.assert(result === Number.MAX_SAFE_INTEGER)
+  common.assert(result === 2n ** 53n + 1n)
 }
 
 /*


### PR DESCRIPTION
## ⚠️ Draft / do not merge

This is a **breaking change** opened for review/discussion (per request). The code and tests are complete and green; it is held as a draft only because merging it is an **API break** that needs a deliberate major-version bump.

## Summary

Closes #323 / #149. 64-bit integers were returned as JS **Number** and lost precision above `Number.MAX_SAFE_INTEGER`:

```js
Gst.CLOCK_TIME_NONE
// before: 18446744073709552000
// after:  18446744073709551615n   ✅ exact
```

They are now marshalled as **BigInt** from both `GIArgumentToV8` and `GValueToV8`:

- fixed-width `gint64` / `guint64`
- **platform-dependent** `glong` / `gulong` / `gsize` / `gssize` — 64-bit on LP64 platforms. g-ir-scanner resolves these to a fixed-width tag, and `G_TYPE_LONG`/`G_TYPE_ULONG` GValues are marshalled as BigInt regardless of platform for consistent behavior.
- **`GType`** (a `gsize`), so the GValue path now matches the `GIArgument` path and `gi.getGType()`.

The IN side accepts **both `Number` and `BigInt`**, so values round-trip exactly in every direction. A new `V8ToInt64`/`V8ToUint64` helper lets the GValue setters take either, and `CanConvertV8ToGValue` accepts `BigInt` for the 64-bit holders.

### Internal change required
Enum/flags member values come from `g_value_info_get_value`, which returns a **`gint64`** — so they'd become BigInt too, and the bindings compare (`type === InfoType.ENUM`) and bitwise-combine (`flags & FLAG`) them as Numbers. `makeEnum()` now coerces enum values back to `Number` (they're small). Without this the bindings don't even bootstrap.

## Tests
All updated to expect `BigInt` for 64-bit / platform-dependent values, several now asserting full precision past `Number.MAX_SAFE_INTEGER` (impossible with Numbers):

- `marshalling__integer` (exact 64-bit round-trips + a platform-width BigInt check)
- `marshalling__gvalue` (`getInt64()` exact + a `glong`/`gulong` BigInt block)
- `marshalling__struct` (`glong` fields)
- `marshalling__bytes` (`gsize` via `getSize()`)
- `marshalling__callback` (`glong` return / out params)
- `conversion__gvalue_uint64` (guint64 property, now exact past 2^53)
- `object__non-introspected` (`gint64` property)
- `union__fields` (`gint64` member, now exact past 2^53)
- `regress__signal` already passed (handler echoes the BigInt back)

Full suite: **75 passing**, with only the pre-existing local `require.js` GIRepository 3.0/2.0 bootstrap failure (environmental, reproduces on `master`, unaffected on CI).

## Remaining decision before merge
- **API break** → major version bump + a migration note (consumers reading 64-bit properties/returns now get `BigInt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)