### PR TITLE
test: expect original property name in invalid-prop error (fix master)

### DIFF
--- a/tests/object__construct_props.js
+++ b/tests/object__construct_props.js
@@ -19,8 +19,8 @@ describe('construct props', () => {
     expect(new Gtk.Image({ 'icon-name': 'go-up' }).iconName, 'go-up')
   })
 
-  it('still rejects unknown names', mustThrow(
-    'Invalid property name: does-not-exist',
+  it('still rejects unknown names (reported as written)', mustThrow(
+    'Invalid property name: doesNotExist',
     () => { new Gtk.Image({ doesNotExist: 1 }) }
   ))
 })


### PR DESCRIPTION
Fixes the `object__construct_props.js` failure on master.

#423 made the "Invalid property name" error report the name as the user wrote it (`doesNotExist`), but this test still asserted the dashed form (`does-not-exist`) — so it failed on every platform. Align the assertion with #423's (correct) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)