### PR TITLE
test: regression test for boxed transfer-full IN double-free (#394)

### DIFF
--- a/tests/conversion__boxed_double_free.js
+++ b/tests/conversion__boxed_double_free.js
@@ -1,0 +1,55 @@
+/*
+ * conversion__boxed_double_free.js
+ *
+ * Regression test for #394: a boxed value obtained from a transfer-full OUT
+ * parameter, then passed into a constructor that takes it transfer-full and
+ * frees it on its own finalization, must not be double-freed.
+ *
+ * GstSdp.SDPMessage.newFromText() returns a GstSDPMessage the JS wrapper owns
+ * (transfer-full out). GstWebRTC.WebRTCSessionDescription.new() takes that sdp
+ * transfer-full and stores it, freeing it when the description is finalized.
+ * Without copying the boxed on the way in, both the sdp wrapper and the
+ * description free the same GstSDPMessage -> `free(): invalid pointer` (SIGABRT)
+ * on garbage collection. node-gtk hands the callee a copy (see
+ * CopyBoxedForTransferFullIn / #409), so both can be collected safely.
+ *
+ * Run with --expose-gc (the test runner does); skipped where the GStreamer
+ * webrtc/sdp libraries aren't installed.
+ */
+
+const gi = require('../lib/')
+const { describe, assert, skip } = require('./__common__.js')
+
+let Gst, GstWebRTC, GstSdp
+try {
+  Gst = gi.require('Gst', '1.0')
+  GstWebRTC = gi.require('GstWebRTC')
+  GstSdp = gi.require('GstSdp')
+  Gst.init([])
+} catch (e) {
+  console.log('GStreamer webrtc/sdp not available, skipping:', e.message)
+  skip()
+}
+
+assert(typeof global.gc === 'function', 'test must run with --expose-gc')
+
+describe('boxed transfer-full IN is not double-freed on GC (#394)', () => {
+  const text = 'v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n'
+
+  // Both the sdp wrapper and the description are locals that become
+  // collectable together — this is what triggers the double free.
+  const build = () => {
+    const [ret, sdp] = GstSdp.SDPMessage.newFromText(text)
+    assert(ret === 0, `newFromText should succeed, got ${ret}`)
+    const desc = new GstWebRTC.WebRTCSessionDescription.new(
+      GstWebRTC.WebRTCSDPType.ANSWER, sdp)
+    return desc.constructor.name
+  }
+
+  assert(build() === 'GstWebRTCSessionDescription',
+    'should construct a WebRTCSessionDescription')
+
+  // If the sdp were double-owned, finalizing both here would abort the process.
+  global.gc()
+  global.gc()
+})


### PR DESCRIPTION
## Summary

Closes #394.

#394 reported a `free(): invalid pointer` SIGABRT on garbage collection from this pattern:

```js
const [ret, sdp] = GstSdp.SDPMessage.newFromText(text)        // sdp: transfer-full OUT, JS wrapper owns it
const a = new GstWebRTC.WebRTCSessionDescription.new(          // takes sdp transfer-full, stores & frees it
  GstWebRTC.WebRTCSDPType.ANSWER, sdp)
// when both `sdp` and `a` are collected -> same GstSDPMessage freed twice
```

### Root cause — already fixed

The double free is the exact bug **already fixed by #409** (`CopyBoxedForTransferFullIn`): a boxed value passed transfer-full IN is copied so the callee frees its own copy, not the JS wrapper's memory. #409 landed **after** the `v1.0.0` release the report was filed against, so current `master` no longer crashes.

I verified the mechanism directly: with the copy in `function.cc` disabled the reproducer aborts (`free(): invalid pointer`, exit 134); with it restored it survives repeated `global.gc()`.

### What this PR adds

#409 only added a fixture test for the **array-of-boxed** transfer-full path (`arrayStructTakeIn`). GIMarshallingTests has **no scalar-boxed transfer-full IN** function, so the scalar `GI_TYPE_TAG_INTERFACE` branch of the fix — the one #394 hits — had no coverage. This adds a regression test using the reported scenario.

- `tests/conversion__boxed_double_free.js` — builds the description from an owned `sdp` and forces GC; **verified to SIGABRT (exit 134) with the fix disabled and pass with it**.
- Skips cleanly where the GStreamer webrtc/sdp libraries aren't installed (same pattern as `conversion__gvalue_uint64.js`).

Full local suite: **76 passing**, only the pre-existing environmental `require.js` GIRepository 3.0/2.0 bootstrap failure (reproduces on `master`, green on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)