### PR TITLE
fix(examples): don't unref the MainLoop in glib-timeout (#429)

### DIFF
--- a/examples/glib-timeout.js
+++ b/examples/glib-timeout.js
@@ -1,5 +1,5 @@
 /*
- * callback.js
+ * glib-timeout.js
  */
 
 const gi = require('../')
@@ -22,4 +22,7 @@ GLib.timeoutAddSeconds(0, 1, () => {
 console.log('Run loop.')
 loop.run()
 console.log('Loop ran.')
-loop.unref()
+// Note: don't call loop.unref() here. node-gtk's wrapper owns the MainLoop's
+// reference and releases it when the wrapper is garbage-collected; an explicit
+// unref() drops it a second time, which double-frees the loop and crashes at
+// process exit when gi.startLoop() is in use (#429).


### PR DESCRIPTION
## Summary

Fixes the crash in `node examples/glib-timeout.js` tracked by #429.

The example balanced `new GLib.MainLoop()` with `loop.unref()` (the C idiom). But node-gtk's boxed wrapper already owns that reference and `g_main_loop_unref()`s it on GC, so the explicit `loop.unref()` drops it a **second time** → double-free of the `GMainLoop`. Standalone that's only a `g_main_loop_unref: ref_count > 0` warning, but with `gi.startLoop()` active the heap corruption faults during Node's loop teardown at exit (SIGSEGV in `uv_close`).

This removes the `loop.unref()` (and fixes the stale `callback.js` header).

## Verified on Ubuntu 26.04 (rootless podman; libffi 3.5.2 / gir 1.86.0 / glib 2.88 / node 22)

| | crashes |
|---|---|
| before (`loop.unref()`) | **30/30** |
| after (this PR) | **0/30** |

Full run is clean: `Run loop. → count 0..3 → Loop ran.`, exit 0.

## Note (separate, not in this PR)

This is a narrow fix for the example. The underlying hazard — node-gtk exposing C `ref()`/`unref()`/`free()` on GC-owned boxed wrappers, so following normal C ownership idioms double-frees — is left as an open design question in #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)