### PR TITLE
fix: disown boxed wrappers freed via *_free/*_unref methods (#429)

### DIFF
--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -458,4 +458,21 @@ void* PointerFromWrapper(Local<Value> value) {
     return boxed;
 }
 
+void DisownBoxed(Local<Value> value) {
+    if (!value->IsObject())
+        return;
+
+    Local<Object> object = TO_OBJECT (value);
+    // Boxed wrappers store the data pointer in field 0 and the Boxed* in field 1.
+    if (object->InternalFieldCount() < 2)
+        return;
+
+    Boxed *box = static_cast<Boxed *>(object->GetAlignedPointerFromInternalField(1));
+    if (box != NULL) {
+        box->owns_memory = false;
+        box->data = NULL;
+    }
+    object->SetAlignedPointerInInternalField(0, NULL);
+}
+
 };

--- a/src/boxed.h
+++ b/src/boxed.h
@@ -41,4 +41,10 @@ Local<FunctionTemplate> GetBoxedTemplate (GIBaseInfo *info, GType gtype);
 Local<Value>            WrapperFromBoxed (GIBaseInfo *info, void *data, ResourceOwnership ownership = kNone);
 void *                  PointerFromWrapper (Local<Value>);
 
+// Relinquish ownership of a boxed wrapper's memory: clears owns_memory so the
+// GC finalizer won't free it, and nulls the data pointer so later use fails
+// cleanly instead of touching freed memory. Used after an introspected method
+// that frees the instance itself (e.g. *_free / *_unref) — see #429.
+void                    DisownBoxed (Local<Value>);
+
 };

--- a/src/function.cc
+++ b/src/function.cc
@@ -69,6 +69,35 @@ static bool IsMethod (GIBaseInfo *info) {
             (flags & GI_FUNCTION_IS_CONSTRUCTOR) == 0);
 }
 
+static bool EndsWith (const char *str, const char *suffix) {
+    size_t str_len = strlen (str);
+    size_t suffix_len = strlen (suffix);
+    return str_len >= suffix_len && strcmp (str + str_len - suffix_len, suffix) == 0;
+}
+
+/* True for an instance method that deallocates the instance itself — a *_free
+ * or *_unref on a boxed/struct/union. node-gtk's wrapper owns the memory and
+ * frees it on GC, so after such a call the wrapper must disown it or GC will
+ * double-free (#429). Restricted to boxed-like containers: GObject lifetime is
+ * handled separately, and gtk_widget_destroy() etc. don't free the wrapper. */
+static bool FreesInstance (GIFunctionInfo *info) {
+    if (!IsMethod (info))
+        return false;
+
+    const char *symbol = g_function_info_get_symbol (info);
+    if (symbol == NULL || !(EndsWith (symbol, "_free") || EndsWith (symbol, "_unref")))
+        return false;
+
+    GIBaseInfo *container = g_base_info_get_container (info);
+    if (container == NULL)
+        return false;
+
+    GIInfoType type = g_base_info_get_type (container);
+    return type == GI_INFO_TYPE_STRUCT
+        || type == GI_INFO_TYPE_UNION
+        || type == GI_INFO_TYPE_BOXED;
+}
+
 static bool ShouldSkipReturn(GIBaseInfo *info, GITypeInfo *return_type) {
     return g_type_info_get_tag(return_type) == GI_TYPE_TAG_VOID
         || g_callable_info_skip_return(info) == TRUE;
@@ -136,6 +165,7 @@ bool FunctionInfo::Init() {
 
     is_method = IsMethod(info);
     can_throw = g_callable_info_can_throw_gerror (info);
+    frees_instance = FreesInstance(info);
 
     n_callable_args = g_callable_info_get_n_args (info);
     n_total_args = n_callable_args;
@@ -568,6 +598,11 @@ Local<Value> FunctionCall (
                 FreeGIArgument (&arg_type, &arg_value, transfer, direction);
         }
     }
+
+    // If this method freed the instance, drop node-gtk's ownership of it so the
+    // GC finalizer won't free it a second time (#429).
+    if (func->frees_instance && !didThrow)
+        DisownBoxed (info.This());
 
     #ifndef __linux__
         delete[] total_arg_values;

--- a/src/function.h
+++ b/src/function.h
@@ -33,6 +33,7 @@ struct FunctionInfo {
 
     bool is_method;
     bool can_throw;
+    bool frees_instance; /* a *_free/*_unref method that deallocates the instance (#429) */
 
     int n_callable_args;
     int n_total_args;

--- a/tests/conversion__boxed_explicit_unref.js
+++ b/tests/conversion__boxed_explicit_unref.js
@@ -1,0 +1,31 @@
+/*
+ * conversion__boxed_explicit_unref.js
+ *
+ * Regression test for #429: calling an introspected method that frees the
+ * instance itself (e.g. GLib.MainLoop's *_unref) must make node-gtk's wrapper
+ * relinquish ownership, so the GC finalizer doesn't free the same memory a
+ * second time. The double-free is a benign warning on lenient allocators but a
+ * hard SIGSEGV with gi.startLoop() on libffi 3.5 (Ubuntu 26).
+ *
+ * Run with --expose-gc (the runner does).
+ */
+
+const gi = require('../lib/')
+const GLib = gi.require('GLib', '2.0')
+const { describe, assert } = require('./__common__.js')
+
+assert(typeof global.gc === 'function', 'test must run with --expose-gc')
+
+describe('explicit unref() of a boxed disowns the wrapper (#429)', () => {
+  // node-gtk owns the MainLoop's reference; calling unref() drops it. Without
+  // disowning, the GC finalizer would unref it again -> double free.
+  let loop = new GLib.MainLoop(null, false)
+  loop.unref()
+
+  loop = null
+  global.gc()
+  global.gc()
+
+  // Reaching here without aborting is the assertion.
+  assert(true, 'survived GC after explicit unref()')
+})


### PR DESCRIPTION
## Summary

Core fix for #429. A boxed/struct wrapper owns its backing memory and frees it on GC (gated by `Boxed::owns_memory`). When user code calls an introspected method that frees the instance itself — e.g. `GLib.MainLoop`'s `unref()`, following the normal C idiom — node-gtk still thought it owned the memory and freed it **again** at GC. That double-free is a benign `g_main_loop_unref: ref_count > 0` warning on lenient allocators, but a hard **SIGSEGV** during node's loop teardown when `gi.startLoop()` is active on libffi 3.5 (Ubuntu 26).

This is the general counterpart to the example fix in #431.

## Fix

After an instance method whose C symbol ends in `_free`/`_unref` on a struct/union/boxed container, disown the wrapper (`src/function.cc` → new `DisownBoxed` in `src/boxed.cc`):

- clear `owns_memory` so the GC finalizer won't free it again;
- null the data pointer so later use fails cleanly rather than as a use-after-free.

Scoped deliberately:
- **boxed/struct/union only** — GObject lifetime is managed separately, and `gtk_widget_destroy()` & co. don't free the wrapper (hence `_free`/`_unref` only, not `_destroy`).
- **Worst case is a leak, not a crash** — if someone `unref()`s a multi-ref object without dropping the last ref, the wrapper simply won't unref at GC. Mixing manual refcounting with node-gtk's GC ownership was already unsupported.

## Verified on Ubuntu 26.04 (rootless podman; libffi 3.5.2 / gir 1.86.0 / glib 2.88 / node 22)

The crashing pattern — `gi.startLoop()` + `new GLib.MainLoop()` + explicit `loop.unref()` + natural exit:

| | crashes |
|---|---|
| before | **30/30** |
| with this fix | **0/30** |

Plus a new regression test `tests/conversion__boxed_explicit_unref.js` (passes), and the full suite stays green locally (76 passing; only the pre-existing env `require.js`).

## Note
Leaves the broader question (should `ref`/`unref`/`free` be hidden entirely?) untouched — this makes the common, idiomatic case safe with a minimal, scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)