### PR TITLE
fix: stop main-loop busy-spin on unref'd libuv handles

### DIFF
--- a/src/loop.cc
+++ b/src/loop.cc
@@ -26,6 +26,8 @@ static Nan::Persistent<Array> loopStack(Nan::New<Array> ());
 struct uv_loop_source {
     GSource source;
     uv_loop_t *loop;
+    gpointer fd_tag;
+    bool fd_polled;
 };
 
 static gboolean loop_source_prepare (GSource *base, int *timeout) {
@@ -44,6 +46,22 @@ static gboolean loop_source_prepare (GSource *base, int *timeout) {
     CallMicrotaskHandlers ();
 
     bool loop_alive = uv_loop_alive (source->loop);
+
+    /* Toggle whether GLib polls uv's backend fd. When the loop is dead we must
+     * stop polling it: an *unref'd* but still-active uv handle (e.g. the async
+     * eventfd left signaling by emscripten/WASM runtimes such as web-tree-sitter,
+     * or by worker_threads) keeps the backend epoll fd perpetually readable.
+     * uv_loop_alive() reports the loop dead (unref'd handles don't count), so we
+     * intend to sleep here, but a polled-and-ready fd makes GLib's poll() return
+     * immediately every iteration -> loop_source_dispatch() busy-spins at 100%
+     * CPU, starving GTK. Masking the fd lets GLib actually block until a GTK
+     * source wakes us; we restore polling as soon as the loop is alive again. */
+    if (source->fd_tag != NULL && loop_alive != source->fd_polled) {
+        g_source_modify_unix_fd (&source->source, source->fd_tag,
+                                 loop_alive ? (GIOCondition) (G_IO_IN | G_IO_OUT | G_IO_ERR)
+                                            : (GIOCondition) 0);
+        source->fd_polled = loop_alive;
+    }
 
     /* If the loop is dead, we can simply sleep forever until a GTK+ source
      * (presumably) wakes us back up again. */
@@ -92,13 +110,15 @@ static GSourceFuncs uv_loop_source_funcs = {
 static GSource *loop_source_new (uv_loop_t *loop) {
     struct uv_loop_source *source = (struct uv_loop_source *) g_source_new (&uv_loop_source_funcs, sizeof (*source));
     source->loop = loop;
+    source->fd_tag = NULL;
+    source->fd_polled = true;
 #if OS_WINDOWS
     // FIXME
     // https://github.com/nodejs/node/issues/36015
 #else
-    g_source_add_unix_fd (&source->source,
-                          uv_backend_fd (loop),
-                          (GIOCondition) (G_IO_IN | G_IO_OUT | G_IO_ERR));
+    source->fd_tag = g_source_add_unix_fd (&source->source,
+                                           uv_backend_fd (loop),
+                                           (GIOCondition) (G_IO_IN | G_IO_OUT | G_IO_ERR));
 #endif
     return &source->source;
 }

--- a/src/loop.cc
+++ b/src/loop.cc
@@ -56,12 +56,14 @@ static gboolean loop_source_prepare (GSource *base, int *timeout) {
      * immediately every iteration -> loop_source_dispatch() busy-spins at 100%
      * CPU, starving GTK. Masking the fd lets GLib actually block until a GTK
      * source wakes us; we restore polling as soon as the loop is alive again. */
+#if !OS_WINDOWS
     if (source->fd_tag != NULL && loop_alive != source->fd_polled) {
         g_source_modify_unix_fd (&source->source, source->fd_tag,
                                  loop_alive ? (GIOCondition) (G_IO_IN | G_IO_OUT | G_IO_ERR)
                                             : (GIOCondition) 0);
         source->fd_polled = loop_alive;
     }
+#endif
 
     /* If the loop is dead, we can simply sleep forever until a GTK+ source
      * (presumably) wakes us back up again. */


### PR DESCRIPTION
## Problem

A GTK app that loads a WASM/emscripten module (e.g. `web-tree-sitter`) maps its window but then pins a CPU core at **100%** with the UI frozen — it looks like a hang.

node-gtk nests libuv's loop inside GLib's by registering `uv_backend_fd` (the epoll fd) into GLib's poll set. When an **unref'd but still-active** uv handle keeps that fd perpetually readable — the self-signaling `uv_async` eventfd left by emscripten/WASM runtimes, or by `worker_threads` — `uv_loop_alive()` reports the loop *dead* (unref'd handles don't count), so `loop_source_prepare()` returns `FALSE` intending to sleep. But the still-polled, ready fd makes GLib's `poll()` wake every iteration, so `loop_source_dispatch()` busy-runs `uv_run(NOWAIT)` forever, starving GTK.

### Evidence

Idle `loop.run()`, measured with `process.cpuUsage()`:

| | CPU over 2s idle |
|---|---|
| without web-tree-sitter | `0.00s` (sleeps) |
| with web-tree-sitter | `2.00s` (100% spin) |

strace of the spin:
```
ppoll([fd=15 epoll, fd=21 eventfd, …]) → returns instantly (fd=15 POLLIN)
read(21,"\2…")  →  write(21,"\1…") ×2   # unref'd uv_async re-signaling forever
```

## Fix

Store the `g_source_add_unix_fd` tag and toggle the polled events in `loop_source_prepare()`: mask the fd (events `0`) while the loop is dead, restore `G_IO_IN|G_IO_OUT|G_IO_ERR` once it's alive again. GLib then blocks until a GTK source wakes it.

## Verification

- With the fix, the same idle loop drops from `2.00s` → `0.00s` CPU with web-tree-sitter loaded.
- A `setTimeout`/promise scheduled mid-loop **still fires** — ref'd async work re-arms polling, so nothing legitimate is starved.
- Real-world repro (a GtkSourceView editor using web-tree-sitter) now sleeps (`State: S`) instead of spinning (`State: R`, 100%); window is responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)