### PR TITLE
fix: guard ToggleNotify against zapped V8 handle after GC

### DIFF
--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -100,21 +100,41 @@ out:
     return gobject;
 }
 
+struct GObjectWrapper;
+static void GObjectDestroyed(const Nan::WeakCallbackInfo<GObjectWrapper> &data);
+
+struct GObjectWrapper {
+    Nan::Persistent<Object> persistent;
+    GObject *gobject;
+    /* Set to true the moment SetWeak is called. Between that point and the
+     * GObjectDestroyed weak callback actually running, the V8 handle is already
+     * zapped (kGlobalHandleZapValue). If ToggleNotify fires in that window
+     * (because native code adjusts the refcount), touching the persistent
+     * crashes. Guard every persistent access with this flag. */
+    bool dying = false;
+};
+
 static void ToggleNotify(gpointer user_data, GObject *gobject, gboolean toggle_down) {
     void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
 
     g_assert (data != NULL);
 
-    auto *persistent = (Nan::Persistent<Object> *) data;
+    auto *wrapper = (GObjectWrapper *) data;
+
+    /* If GObjectDestroyed is already pending (handle zapped by GC but callback
+     * not yet dispatched), don't touch the persistent — it's dead. */
+    if (wrapper->dying)
+        return;
 
     if (toggle_down) {
         /* We're dropping from 2 refs to 1 ref. We are the last holder. Make
          * sure that that our weak ref is installed. */
-        persistent->SetWeak (gobject, GObjectDestroyed, v8::WeakCallbackType::kParameter);
+        wrapper->dying = true;
+        wrapper->persistent.SetWeak (wrapper, GObjectDestroyed, v8::WeakCallbackType::kParameter);
     } else {
         /* We're going from 1 ref to 2 refs. We can't let our wrapper be
          * collected, so make sure that our reference is persistent */
-        persistent->ClearWeak ();
+        wrapper->persistent.ClearWeak ();
     }
 }
 
@@ -123,8 +143,10 @@ static void AssociateGObject(Local<Object> object, GObject *gobject, GType gtype
 
     SET_OBJECT_GTYPE(object, gtype);
 
-    auto *persistent = new Nan::Persistent<Object>(object);
-    g_object_set_qdata (gobject, GNodeJS::object_quark(), persistent);
+    auto *wrapper = new GObjectWrapper();
+    wrapper->gobject = gobject;
+    wrapper->persistent.Reset(object);
+    g_object_set_qdata (gobject, GNodeJS::object_quark(), wrapper);
 
     // Because we can't sink floating ref and add toggle ref at the same time,
     // first sink the floating ref, add the toggle ref, and then release the
@@ -183,16 +205,12 @@ static void GObjectConstructor(const FunctionCallbackInfo<Value> &info) {
     }
 }
 
-static void GObjectDestroyed(const Nan::WeakCallbackInfo<GObject> &data) {
-    GObject *gobject = data.GetParameter ();
+static void GObjectDestroyed(const Nan::WeakCallbackInfo<GObjectWrapper> &data) {
+    GObjectWrapper *wrapper = data.GetParameter ();
+    GObject *gobject = wrapper->gobject;
 
-    void *type_data = g_object_get_qdata (gobject, GNodeJS::object_quark());
-    auto *persistent = (Nan::Persistent<Object> *) type_data;
-    delete persistent;
-
-    /* We're destroying the wrapper object, so make sure to clear out
-     * the qdata that points back to us. */
     g_object_set_qdata (gobject, GNodeJS::object_quark(), NULL);
+    delete wrapper;
 
     g_object_remove_toggle_ref (gobject, &ToggleNotify, NULL);
 }
@@ -657,9 +675,8 @@ Local<Value> WrapperFromGObject(GObject *gobject) {
     void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
 
     if (data) {
-        /* Easy case: we already have an object. */
-        auto *persistent = (Nan::Persistent<Object> *) data;
-        auto obj = New<Object> (*persistent);
+        auto *wrapper = (GObjectWrapper *) data;
+        auto obj = New<Object> (wrapper->persistent);
         return obj;
     }
 

--- a/tests/object__toggle_ref_race.js
+++ b/tests/object__toggle_ref_race.js
@@ -1,0 +1,47 @@
+/*
+ * object__toggle_ref_race.js
+ *
+ * Regression test for the ToggleNotify race condition: when a GObject wrapper
+ * goes out of JS scope, V8 GC zaps the Persistent handle and schedules
+ * GObjectDestroyed. In the window between the zap and the callback, native code
+ * can call g_object_unref and hit the toggle point (refcount 2→1), which fires
+ * ToggleNotify. Before the fix, ToggleNotify would call SetWeak on the already-
+ * zapped handle and crash with "Check failed: object_ != kGlobalHandleZapValue".
+ *
+ * Reproduced by: creating a GObject, adding it to a Gio.ListStore (which takes
+ * a native ref, refcount=2), dropping the JS reference, forcing GC (zapping the
+ * handle), then removing it from the store (refcount 2→1, ToggleNotify fires).
+ */
+
+const gi = require('../lib/')
+const { describe } = require('./__common__.js')
+
+if (typeof global.gc !== 'function') {
+  console.error('test must run with --expose-gc')
+  process.exit(1)
+}
+
+const Gio = gi.require('Gio', '2.0')
+const GObject = gi.require('GObject', '2.0')
+
+describe('ToggleNotify with zapped persistent does not crash', () => {
+  const store = Gio.ListStore.new(GObject.TYPE_OBJECT)
+
+  // Create a GObject and add it to the store. The store takes a native ref so
+  // refcount = 2 (toggle ref + store). The JS variable then goes out of scope.
+  ;(() => {
+    const stream = new Gio.MemoryInputStream()
+    store.append(stream)
+  })()
+
+  // Force GC: V8 zaps the Persistent handle and schedules GObjectDestroyed.
+  global.gc()
+  global.gc()
+
+  // Remove from store: store calls g_object_unref (refcount 2→1).
+  // ToggleNotify fires — without the fix this crashes.
+  store.remove(0)
+
+  global.gc()
+  global.gc()
+})


### PR DESCRIPTION
## Summary

- `ToggleNotify` could be called while the V8 Persistent handle for a GObject wrapper was already zapped by GC (but before `GObjectDestroyed` had a chance to run and remove the toggle ref). Calling `SetWeak` on a zapped handle crashed with `Check failed: object_ != kGlobalHandleZapValue`.
- Replace the bare `Nan::Persistent*` qdata with a `GObjectWrapper` struct carrying a `dying` flag + `gobject` backref. `ToggleNotify` sets `dying = true` before `SetWeak` and bails early if already set.
- `GObjectDestroyed` now receives `GObjectWrapper*` as its `kParameter`, giving it the `gobject` backref without an extra qdata lookup.
- Adds a regression test using `Gio.ListStore` + `--expose-gc` to reliably trigger the refcount 2→1 drop in the race window.

## Test plan

- [ ] `node --expose-gc tests/object__toggle_ref_race.js` passes
- [ ] Applications that create many short-lived GObject wrappers in signal callbacks (e.g. `GtkSignalListItemFactory` setup/bind) no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)