### PR TITLE
fix: drain Promise microtasks under GLib main loop in ES modules (#442)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ is being invoked from within a microtask. Two consequences for ESM code:
 Under CommonJS (and inside signal callbacks) nothing changes: the run calls block
 synchronously and return their value exactly as before.
 
+> **Design note (may be reconsidered).** Two approaches were considered for #442:
+>
+> - **Transparent auto-defer (chosen).** node-gtk detects the microtask context
+>   and defers the blocking call automatically, so existing ESM code keeps
+>   working with no changes. The cost is the leaky behavior above: under ESM the
+>   run call no longer blocks, which is surprising and silently breaks idioms
+>   like `process.exit(app.run([]))`.
+> - **Explicit async API (alternative).** Keep the blocking calls strictly
+>   synchronous and add awaitable variants (e.g. `await loop.runAsync()`),
+>   leaving ESM users to opt in. This has clean, predictable semantics and no
+>   hidden return-immediately behavior, but it does *not* transparently fix
+>   existing ESM code — users must change their code, and plain `loop.run()`
+>   would still starve microtasks under ESM (or would need to throw/warn).
+>
+> The transparent approach was chosen to fix existing code out of the box, but
+> given the leaky semantics this trade-off may be revisited — possibly moving to
+> (or also offering) the explicit async API.
+
 You can also easily create custom applications:
 
 [A web browser (using WebKit2GTK)](./examples/browser.js)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ process.exit(app.run([]));
   <img src="./img/hello-world.png" style="width: 290px; height: auto;"/>
 </p>
 
+#### ES modules
+
+The example above is CommonJS. node-gtk also works under ES modules, but with one
+behavioral difference around the blocking main-loop calls (`GLib.MainLoop.run`,
+`Gio`/`Gtk.Application.run`, `Gtk.main`).
+
+Under ESM, a module's top-level body runs as a V8 *microtask*. If a blocking
+loop call ran synchronously from there, it would nest inside V8's microtask
+drain and starve every `Promise`/`async` continuation (so `await fetch(...)`,
+`fs/promises`, etc. would never settle) for the entire lifetime of the loop —
+see [#442](https://github.com/romgrk/node-gtk/issues/442). To avoid this,
+node-gtk defers the blocking call to the next event-loop tick when it detects it
+is being invoked from within a microtask. Two consequences for ESM code:
+
+- The run call **returns immediately** instead of blocking until quit, so any
+  code placed *after* it executes *before* the loop. Make the run call the last
+  statement, and do cleanup/exit from your quit/`close-request` handler.
+- Its **return value is not available** (e.g. the application's exit status), so
+  don't wrap it like `process.exit(app.run([]))` — call `app.run([])` on its own
+  and exit from the handler instead.
+
+Under CommonJS (and inside signal callbacks) nothing changes: the run calls block
+synchronously and return their value exactly as before.
+
 You can also easily create custom applications:
 
 [A web browser (using WebKit2GTK)](./examples/browser.js)

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -6,6 +6,7 @@ const internal = require('./native.js')
 
 module.exports = {
   start,
+  runLoopEntry,
 }
 
 
@@ -29,6 +30,39 @@ function start() {
   global.setImmediate = wrappedLoopFunction(setImmediate)
 
   internal.StartLoop()
+}
+
+
+/**
+ * Runs a blocking main-loop entry point (e.g. GLib.MainLoop.run,
+ * Gio.Application.run, Gtk.main) so that Promise/async continuations keep
+ * draining while it blocks.
+ *
+ * Under ES modules the top-level body executes as a V8 microtask, so a blocking
+ * call made directly from it nests inside V8's microtask drain. V8 refuses
+ * nested microtask checkpoints, so any pending Promise/async continuation is
+ * starved for the entire lifetime of the loop. Deferring the blocking call to a
+ * macrotask lets the module's top-level microtask return first, so the queue
+ * drains and the loop integration takes over from a clean (non-nested) state.
+ *
+ * Under CommonJS (and inside signal callbacks) we are not in a microtask, so we
+ * run synchronously and preserve the original blocking semantics exactly.
+ *
+ * https://github.com/romgrk/node-gtk/issues/442
+ *
+ * Returns the native call's result when run synchronously (so e.g.
+ * `const status = app.run()` keeps working under CommonJS); returns undefined
+ * when deferred, since the result is not yet available.
+ *
+ * @param {Function} run - performs the blocking native call
+ * @returns {*} the native return value, or undefined when deferred
+ */
+function runLoopEntry(run) {
+  if (internal.IsRunningMicrotasks()) {
+    setImmediate(run)
+    return undefined
+  }
+  return run()
 }
 
 

--- a/lib/overrides/GLib-2.0.js
+++ b/lib/overrides/GLib-2.0.js
@@ -3,6 +3,7 @@
  */
 
 const internal = require('../native.js')
+const { runLoopEntry } = require('../loop.js')
 
 exports.apply = (GLib) => {
 
@@ -10,17 +11,19 @@ exports.apply = (GLib) => {
     GLib.MainLoop.prototype._quit = GLib.MainLoop.prototype.quit
 
     GLib.MainLoop.prototype.run = function run() {
-        /* Run before we enter the loop otherwise pending microtasks
-         * are not run */
-        process._tickCallback()
-
         const loopStack = internal.GetLoopStack()
-
         loopStack.push(() => this.quit())
-        this._run()
-        if (this._userQuit)
-            loopStack.pop()
-        delete this._userQuit
+
+        return runLoopEntry(() => {
+            /* Run before we enter the loop otherwise pending microtasks
+             * are not run */
+            process._tickCallback()
+
+            this._run()
+            if (this._userQuit)
+                loopStack.pop()
+            delete this._userQuit
+        })
     }
     GLib.MainLoop.prototype.quit = function quit() {
         this._userQuit = true

--- a/lib/overrides/Gio-2.0.js
+++ b/lib/overrides/Gio-2.0.js
@@ -1,0 +1,26 @@
+/*
+ * Gio-2.0.js
+ */
+
+const { runLoopEntry } = require('../loop.js')
+
+exports.apply = (Gio) => {
+
+    Gio.Application.prototype._run = Gio.Application.prototype.run
+
+    /* g_application_run() blocks until the application quits. Under ES modules
+     * this would starve Promise/async continuations; runLoopEntry() defers the
+     * blocking call when needed so they keep draining. See loop.js / #442.
+     *
+     * Note: when deferred (ESM), the exit status is not available synchronously,
+     * so `app.run()` returns undefined instead of the status code in that case. */
+    Gio.Application.prototype.run = function run(...args) {
+        return runLoopEntry(() => {
+            /* Run before we enter the loop otherwise pending microtasks
+             * are not run */
+            process._tickCallback()
+
+            return this._run(...args)
+        })
+    }
+}

--- a/lib/overrides/Gtk-3.0.js
+++ b/lib/overrides/Gtk-3.0.js
@@ -3,6 +3,7 @@
  */
 
 const internal = require('../native.js')
+const { runLoopEntry } = require('../loop.js')
 
 /**
  * @typedef {Object} Dimension
@@ -27,10 +28,6 @@ exports.apply = (Gtk) => {
     let userCallingQuit = false
 
     Gtk.main = function main() {
-        /* Run before we enter the loop otherwise pending microtasks
-         * are not run */
-        process._tickCallback()
-
         const loopStack = internal.GetLoopStack()
 
         /*
@@ -42,17 +39,25 @@ exports.apply = (Gtk) => {
 
         loopStack.push(originalQuit)
 
-        originalMain()
+        /* runLoopEntry() defers the blocking call under ES modules so pending
+         * Promise/async continuations keep draining. See loop.js / #442. */
+        return runLoopEntry(() => {
+            /* Run before we enter the loop otherwise pending microtasks
+             * are not run */
+            process._tickCallback()
 
-        if (userCallingQuit) {
-          loopStack.pop()
-        }
+            originalMain()
 
-        userCallingQuit = false
+            if (userCallingQuit) {
+              loopStack.pop()
+            }
 
-        if (Gtk.mainLevel() === 0) {
-          placeholderIntervalID = clearInterval(placeholderIntervalID)
-        }
+            userCallingQuit = false
+
+            if (Gtk.mainLevel() === 0) {
+              placeholderIntervalID = clearInterval(placeholderIntervalID)
+            }
+        })
     }
 
     Gtk.mainQuit = function mainQuit() {

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -380,6 +380,10 @@ NAN_METHOD(StartLoop) {
     GNodeJS::StartLoop ();
 }
 
+NAN_METHOD(IsRunningMicrotasks) {
+    info.GetReturnValue().Set(Nan::New<Boolean>(GNodeJS::IsRunningMicrotasks ()));
+}
+
 NAN_METHOD(GetBaseClass) {
     auto tpl = GNodeJS::GetBaseClassTemplate ();
     auto fn = Nan::GetFunction (tpl).ToLocalChecked();
@@ -425,6 +429,7 @@ void InitModule(Local<Object> exports, Local<Value> module, void *priv) {
     Nan::Export(exports, "ObjectPropertyGetter", ObjectPropertyGetter);
     Nan::Export(exports, "ObjectPropertySetter", ObjectPropertySetter);
     Nan::Export(exports, "StartLoop",            StartLoop);
+    Nan::Export(exports, "IsRunningMicrotasks",  IsRunningMicrotasks);
     Nan::Export(exports, "GetLoopStack",         GetLoopStack);
     Nan::Export(exports, "RegisterClass",        RegisterClass);
     Nan::Export(exports, "RegisterVFunc",        RegisterVFunc);

--- a/src/loop.cc
+++ b/src/loop.cc
@@ -167,6 +167,20 @@ void CallMicrotaskHandlers () {
 #endif
 }
 
+bool IsRunningMicrotasks() {
+    /* True while V8 is draining the microtask queue. Under ES modules the
+     * top-level body executes as a microtask, so a synchronous blocking call
+     * (e.g. g_main_loop_run) made from it nests inside this drain. V8 refuses
+     * nested microtask checkpoints, so any Promise/async continuation queued
+     * by user code is stuck until the blocking call returns. Callers use this
+     * to detect that situation and defer the blocking call to a macrotask so
+     * the module's top-level microtask can return and the queue can drain.
+     *
+     * - https://github.com/romgrk/node-gtk/issues/442
+     */
+    return MicrotasksScope::IsRunningMicrotasks(Isolate::GetCurrent());
+}
+
 void StartLoop() {
     GSource *source = loop_source_new (uv_default_loop ());
     g_source_attach (source, NULL);

--- a/src/loop.h
+++ b/src/loop.h
@@ -12,6 +12,8 @@ namespace GNodeJS {
 
   void StartLoop();
 
+  bool IsRunningMicrotasks();
+
   void QuitLoopStack();
 
   Local<Array> GetLoopStack();

--- a/tests/loop__esm_microtasks.js
+++ b/tests/loop__esm_microtasks.js
@@ -1,0 +1,22 @@
+/*
+ * loop__esm_microtasks.js
+ *
+ * Regression test for #442: under ES modules, Promise/async continuations were
+ * starved for the entire lifetime of GLib.MainLoop.run() (they worked under
+ * CommonJS). Spawns the ESM repro as a child process and asserts it succeeds.
+ */
+
+const path = require('path')
+const child_process = require('child_process')
+const { assert } = require('./__common__')
+
+const child = path.join(__dirname, 'loop__esm_microtasks.mjs')
+const result = child_process.spawnSync(process.execPath, [child], { encoding: 'utf8' })
+
+process.stdout.write(result.stdout)
+process.stderr.write(result.stderr)
+
+assert(
+  result.status === 0,
+  `ESM microtasks should drain while the main loop runs (child exited ${result.status})`
+)

--- a/tests/loop__esm_microtasks.mjs
+++ b/tests/loop__esm_microtasks.mjs
@@ -1,0 +1,47 @@
+/*
+ * loop__esm_microtasks.mjs
+ *
+ * Promise/async microtasks must keep draining while GLib.MainLoop.run() blocks,
+ * even under ES modules (where the top-level body runs as a V8 microtask).
+ * https://github.com/romgrk/node-gtk/issues/442
+ *
+ * Run as a child process by loop__esm_microtasks.js (the .mjs is not picked up
+ * by the test runner, which only collects .js files). Exits 0 on success.
+ */
+
+import { createRequire } from 'node:module'
+
+const gi = createRequire(import.meta.url)('..')
+const GLib = gi.require('GLib', '2.0')
+
+const loop = GLib.MainLoop.new(null, false)
+
+let microtaskDrained = false
+Promise.resolve().then(() => { microtaskDrained = true })
+
+let asyncDrained = false
+;(async () => { await Promise.resolve(); asyncDrained = true })()
+
+let result = null
+GLib.timeoutAdd(GLib.PRIORITY_DEFAULT, 100, () => {
+  /* 100ms into the loop the microtasks scheduled before run() must have drained */
+  result = { microtaskDrained, asyncDrained }
+  loop.quit()
+  return false
+})
+
+gi.startLoop()
+
+/* Under ESM this returns immediately (the blocking call is deferred to a
+ * macrotask so the module's top-level microtask can return); the loop still
+ * runs to completion afterwards. */
+loop.run()
+
+process.on('exit', () => {
+  if (!result || !result.microtaskDrained || !result.asyncDrained) {
+    console.error('FAIL: microtasks did not drain during the loop under ESM:', result)
+    process.exitCode = 1
+    return
+  }
+  console.log('OK: microtasks drained during the loop under ESM')
+})


### PR DESCRIPTION
Fixes #442.

## Problem

Under **ES modules**, `Promise`/`async` continuations are not drained while a blocking main-loop call runs — they only flush after the loop exits. Under **CommonJS** the same code works. libuv macrotasks (`setTimeout`, child processes) fire in both. In practice `await fetch(...)`, `fs/promises`, and promise-based libraries appear frozen for the lifetime of the loop in ESM apps.

## Root cause

An ES module's top-level body executes as a **V8 microtask**. A synchronous blocking main-loop call (`GLib.MainLoop.run`, `Gio`/`Gtk.Application.run`, `Gtk.main`) made from it therefore nests *inside* V8's microtask drain. V8 refuses nested microtask checkpoints (`MicrotasksScope::IsRunningMicrotasks()` is true), so the user's queued continuations sit behind the never-returning module-eval microtask and can't run until the loop quits. CommonJS top-level runs at scope depth 0, so it was never affected.

Confirmed independent of ESM by reproducing the exact failure in CommonJS via `queueMicrotask(() => { …loop.run() })`.

## Fix

- New native `internal.IsRunningMicrotasks()` wrapping the public `v8::MicrotasksScope::IsRunningMicrotasks` (available Node 22–26).
- `runLoopEntry(run)` in `lib/loop.js`: when invoked from within a microtask, defer the blocking call to the next tick via `setImmediate` so the module's top-level microtask returns and the queue drains; otherwise run synchronously and return its value.
- Wired into the `GLib`, `Gtk` (`Gtk.main`) and new `Gio` (`Application.run`) overrides.

CommonJS and signal-callback usage are unchanged (not in a microtask → synchronous, same return value).

## Tradeoff (documented)

Under ESM the run call **returns immediately** instead of blocking (it can't block — top-level *is* a microtask), so its return value is unavailable and code after it runs before the loop. The common `process.exit(app.run([]))` idiom would exit instantly under ESM. Added a README "ES modules" section: call the run method last and exit from the quit/`close-request` handler.

## Verification

- Original `.mjs` repro from the issue: microtasks / `await` / `fs/promises` now drain mid-loop; `.cjs` unchanged.
- Existing `tests/loop.js` (Gtk + Application, CommonJS): passes.
- New regression test `tests/loop__esm_microtasks.js` (spawns an `.mjs` child): passes.
- Full suite: 82 passing (the one failure, `require.js`, is a pre-existing environment issue unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)