### PR TITLE
fix: release transfer-full GObject return refs so they can be GC'd

### DIFF
--- a/src/function.cc
+++ b/src/function.cc
@@ -134,6 +134,43 @@ bool IsDestroyNotify (GIBaseInfo *info) {
         && strcmp(g_base_info_get_namespace(info), "GLib") == 0;
 }
 
+/*
+ * A transfer-full GObject return value hands node-gtk an *owning* reference. The
+ * JS wrapper only needs node-gtk's toggle reference, so that extra reference has
+ * to be released — otherwise the refcount never falls back to 1, ToggleNotify
+ * never flips the V8 handle to weak, and the GObject (plus its wrapper) leaks for
+ * the lifetime of the process. This is the leak reported in #446: objects from
+ * GI function returns (`Type.new()`, transfer-full getters, …) were never GC'd,
+ * while `new Type()` — which drops its construction ref in GObjectConstructor —
+ * was. It is the return-value counterpart of OUT GObject args, which
+ * FreeGIArgument already balances; the return value is otherwise never freed on
+ * the success path. (The IN counterpart is RefObjectForTransferFullIn, #439.)
+ *
+ * Must be sampled *before* the value is wrapped: associating the wrapper sinks a
+ * floating reference (consuming it), after which a floating incoming ref (nothing
+ * extra to drop) is indistinguishable from a real owned one. G_IS_OBJECT excludes
+ * GParamSpec (wrapped via ParamSpec::FromGParamSpec) and boxed/fundamental
+ * interface types.
+ */
+static bool OwnsExtraGObjectReturnRef(GITypeInfo *return_type, GITransfer transfer, gpointer ptr) {
+    if (transfer != GI_TRANSFER_EVERYTHING || ptr == NULL)
+        return false;
+
+    if (g_type_info_get_tag(return_type) != GI_TYPE_TAG_INTERFACE)
+        return false;
+
+    GIBaseInfo *iface = g_type_info_get_interface(return_type);
+    GIInfoType  itype = g_base_info_get_type(iface);
+
+    bool result =
+        (itype == GI_INFO_TYPE_OBJECT || itype == GI_INFO_TYPE_INTERFACE)
+        && G_IS_OBJECT(ptr)
+        && !g_object_is_floating(ptr);
+
+    g_base_info_unref(iface);
+    return result;
+}
+
 
 /**
  * The constructor just stores the GIBaseInfo ref. The rest of the
@@ -549,6 +586,13 @@ Local<Value> FunctionCall (
 
     } else if (!use_return_value) {
 
+        // A transfer-full GObject return hands us an extra owning reference on
+        // top of the wrapper's toggle ref; drop it once wrapped so the object
+        // isn't pinned alive forever (#446). Sampled now, before wrapping sinks
+        // any floating reference.
+        bool release_return_ref =
+            OwnsExtraGObjectReturnRef(&return_type, return_transfer, return_value_stack.v_pointer);
+
         // Value transferred to jsReturnValue
         jsReturnValue = func->JsReturnValue (
                 info.This(),
@@ -556,6 +600,9 @@ Local<Value> FunctionCall (
                 &return_value_stack,
                 callable_arg_values,
                 return_transfer);
+
+        if (release_return_ref)
+            g_object_unref (return_value_stack.v_pointer);
     } else {
 
         // Value returned in return_value

--- a/tests/object__gi_return_leak.js
+++ b/tests/object__gi_return_leak.js
@@ -1,0 +1,56 @@
+/*
+ * object__gi_return_leak.js
+ *
+ * Regression test for #446: GObjects returned from GI functions leaked.
+ *
+ * A transfer-full GObject return (constructor helpers like `Type.new()`, and
+ * transfer-full returns generally) hands node-gtk an owning reference on top of
+ * the wrapper's toggle ref. node-gtk only needs the toggle ref, so that extra
+ * reference must be released; otherwise the refcount never falls back to 1,
+ * ToggleNotify never flips the V8 handle to weak, and the object (and its
+ * wrapper) is pinned alive forever. The same type built with `new Type()` — which
+ * drops its construction ref in GObjectConstructor — was collected correctly, so
+ * the leak was specific to the GI-return path.
+ *
+ * Here we create many GMenu via Gio.Menu.new(), drop every reference, and force
+ * GC. With the bug essentially none are reclaimed (a 1:1 leak); with the fix the
+ * wrappers go weak and are collected.
+ */
+
+const assert = require('assert')
+const gi = require('../lib/')
+const { describe } = require('./__common__.js')
+
+if (typeof global.gc !== 'function') {
+  console.error('test must run with --expose-gc')
+  process.exit(1)
+}
+
+const Gio = gi.require('Gio', '2.0')
+
+describe('GObjects returned from GI functions are GC-collectable', async () => {
+  const N = 2000
+  let collected = 0
+  const registry = new FinalizationRegistry(() => { collected++ })
+
+  ;(() => {
+    for (let i = 0; i < N; i++) {
+      // Gio.Menu.new() is a GI function return (transfer-full).
+      const m = Gio.Menu.new()
+      registry.register(m)
+      m.freeze() // touch it, then drop every reference
+    }
+  })()
+
+  for (let g = 0; g < 12 && collected < N; g++) {
+    global.gc()
+    await new Promise(r => setImmediate(r))
+  }
+
+  // With the leak ~0 are collected; with the fix nearly all are. The slack
+  // tolerates the handful that may still be pinned by a handle scope / the V8
+  // stack at GC time.
+  assert(
+    collected >= N * 0.8,
+    `expected GMenu wrappers from Gio.Menu.new() to be collected, got ${collected}/${N}`)
+})


### PR DESCRIPTION
Fixes #446.

## Problem

GObjects returned from GI functions — constructor helpers like `Type.new()`, and transfer-full returns generally — were never collected, even after every JS reference was dropped and GC was forced repeatedly. The same type built with `new Type()` was collected correctly, so the leak was specific to the GI-return path. The reporter hit a monotonically growing live heap (and increasingly long major-GC pauses) from a git poll creating Ggit objects via `.new()` on a timer.

| construction | created | alive after dropping all refs + GC×8 |
|---|---|---|
| `Gio.Menu.new()` (GI function) | 10000 | **10001** → **2** (fixed) |
| `new Gio.Menu()` (JS constructor) | 10000 | 2 |

## Root cause

A transfer-full return hands node-gtk an *owning* reference on top of the wrapper's toggle ref. node-gtk only needs the toggle ref, so the extra reference must be released; otherwise the refcount never falls back to 1, `ToggleNotify` never flips the V8 handle to weak (`SetWeak`), and the object (and its wrapper) is pinned alive for the lifetime of the process.

- `new Type()` works because `GObjectConstructor` drops its construction ref.
- OUT GObject args work because `FreeGIArgument` already drops their transfer-full ref.
- The **return value** is never freed on the success path, so it leaked 1:1 and unbounded.

## Fix

After wrapping the return value, drop the extra owning reference for a transfer-full GObject return — the return-value counterpart of the OUT-arg balance and of `RefObjectForTransferFullIn` (the #439 IN-side fix).

Ownership is sampled *before* wrapping, since associating the wrapper sinks any floating reference. The helper guards with `G_IS_OBJECT` (excludes `GParamSpec` / boxed / fundamental interface types) and `!g_object_is_floating` (a sunk floating ref is nothing extra to drop), so floating widgets and transfer-none returns are left untouched.

## Verification

- Issue's exact repro: `Gio.Menu.new()` goes from 10001 alive → **2 alive**, matching `new Gio.Menu()`.
- New regression test `tests/object__gi_return_leak.js` (creates many `Gio.Menu.new()`, drops refs, GCs, asserts the wrappers are reclaimed via `FinalizationRegistry`).
- Full suite: **84 passing** including the new test. The only failure (`require.js`) is a pre-existing, environment-specific typelib conflict (PeasGtk / GIRepository 3.0 vs 2.0) that fails identically on unmodified `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)