### PR TITLE
feat: make `registerClass()` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,8 @@ Changes to be released are kept in the unreleased section.
 
 ### Features
 
-- **`registerClass()` is now optional.** The first `new MySubclass()` registers
-  an unregistered JS subclass on demand (including any not-yet-registered
-  ancestors) and installs its vfunc overrides, so you no longer need to call
-  `registerClass` for the common case. It is still available — and still required
-  — when you need the GType before constructing an instance (e.g. `getGType`,
-  GtkBuilder templates). Calling it on an already-registered class is a no-op.
+- **[`registerClass()`](./doc/api.md#register-class-klass) is now optional** —
+  the first `new MySubclass()` registers the subclass on demand.
 - **Direct ESM imports.** Import a namespace with the `gi:` scheme
   (`import Gtk from 'gi:Gtk-4.0'`) after running with
   `node --import node-gtk/register` (Node ≥ 20.6); node-gtk's own API is importable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Changes to be released are kept in the unreleased section.
 
 ### Features
 
+- **`registerClass()` is now optional.** The first `new MySubclass()` registers
+  an unregistered JS subclass on demand (including any not-yet-registered
+  ancestors) and installs its vfunc overrides, so you no longer need to call
+  `registerClass` for the common case. It is still available — and still required
+  — when you need the GType before constructing an instance (e.g. `getGType`,
+  GtkBuilder templates). Calling it on an already-registered class is a no-op.
 - **Direct ESM imports.** Import a namespace with the `gi:` scheme
   (`import Gtk from 'gi:Gtk-4.0'`) after running with
   `node --import node-gtk/register` (Node ≥ 20.6); node-gtk's own API is importable

--- a/doc/api.md
+++ b/doc/api.md
@@ -86,3 +86,5 @@ By default the GType name is the class name; override it with a static
 | ----- | -------- | ---------------------------------------------------- |
 | klass | `Class`  | the class to register (must extend a GObject type)   |
 
+Returns `klass`, so it can be assigned or used as a decorator.
+

--- a/doc/api.md
+++ b/doc/api.md
@@ -69,8 +69,14 @@ Returns a list of available modules
 #### registerClass(klass)
 
 Registers a JS class (which must extend a GObject type) as a new GType, so it can
-be instantiated and used like a native type. The parent type must be registered
-first.
+be instantiated and used like a native type.
+
+**This call is optional.** The first time you do `new MySubclass()`, node-gtk
+registers the subclass on demand (along with any not-yet-registered ancestors),
+so most code never needs to call `registerClass` explicitly. Call it when you
+need the GType *before* constructing an instance — e.g. to read it with
+`getGType`, reference it by name in a GtkBuilder template, or use it as another
+type's property/child type. Calling it on an already-registered class is a no-op.
 
 By default the GType name is the class name; override it with a static
 `GTypeName`. Vfunc overrides are matched by the `snake_case` of the method name

--- a/examples/gtk-4-custom-widget.mjs
+++ b/examples/gtk-4-custom-widget.mjs
@@ -4,7 +4,6 @@
  * Run with:  node --import node-gtk/register examples/gtk-4-custom-widget.mjs
  */
 
-import { registerClass } from 'node-gtk'
 import GLib from 'gi:GLib-2.0'
 import Gtk from 'gi:Gtk-4.0'
 import Gdk from 'gi:Gdk-4.0'
@@ -38,7 +37,8 @@ class CustomWidget extends Gtk.Widget {
   }
 }
 
-registerClass(CustomWidget)
+/* No registerClass(CustomWidget) needed: the first `new CustomWidget()` below
+ * registers the GType and installs the `measure`/`snapshot` vfunc overrides. */
 
 
 /* Setup & start the application */

--- a/lib/register-class.js
+++ b/lib/register-class.js
@@ -11,16 +11,41 @@ const GObject = module_.require('GObject')
 
 module.exports = registerClass
 
+// Make registerClass() optional: the first `new Subclass()` of an unregistered
+// JS subclass lazily registers it through this hook (see GObjectConstructor in
+// src/gobject.cc). registerClass() stays available for callers that need the
+// GType before constructing (e.g. getGType, GtkBuilder templates).
+internal.SetLazyClassRegister(registerClass)
+
+// A registered class owns its `__gtype__` (native classes via the prototype
+// template, JS classes via registerClass below); an unregistered subclass only
+// inherits one. Used to make registration idempotent and to find ancestors that
+// still need registering.
+function isRegistered(klass) {
+  return Object.prototype.hasOwnProperty.call(klass.prototype, '__gtype__')
+}
+
 /**
  * Create a new GObject type
  * @param {Class} klass - The class to register
  * @param {string} [klass.GTypeName] - The name of the GType (klass.name by default)
+ * @returns {Class} the same class (so it can be assigned or used as a decorator)
  */
 function registerClass(klass) {
+  // Idempotent: a class that already owns a GType is registered. This also makes
+  // the lazy-on-first-construct path a no-op for explicitly-registered classes.
+  if (isRegistered(klass))
+    return klass
+
   const parent = Object.getPrototypeOf(klass.prototype).constructor
 
   if (!(klass.prototype instanceof GObject.Object))
     throw new Error(`Invalid base class (${parent.name})`)
+
+  // Register any unregistered ancestor first, so a subclass can be constructed
+  // (or registered) without its superclass having been registered by hand.
+  if (!isRegistered(parent))
+    registerClass(parent)
 
   const name = createGTypeName(klass)
   const gtype = GObject.typeFromName(name)
@@ -41,6 +66,8 @@ function registerClass(klass) {
 
   // Setup virtual functions
   setupVirtualFunctions(klass, klassGtype, parentGtype)
+
+  return klass
 }
 
 // Helpers

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -405,6 +405,10 @@ NAN_METHOD(GetModuleCache) {
     info.GetReturnValue().Set(Nan::New<Object>(GNodeJS::moduleCache));
 }
 
+NAN_METHOD(SetLazyClassRegister) {
+    GNodeJS::ObjectClass::SetLazyClassRegister(info);
+}
+
 NAN_METHOD(RegisterClass) {
     GNodeJS::ObjectClass::RegisterClass(info);
 }
@@ -435,6 +439,7 @@ void InitModule(Local<Object> exports, Local<Value> module, void *priv) {
     Nan::Export(exports, "StartLoop",            StartLoop);
     Nan::Export(exports, "IsRunningMicrotasks",  IsRunningMicrotasks);
     Nan::Export(exports, "GetLoopStack",         GetLoopStack);
+    Nan::Export(exports, "SetLazyClassRegister", SetLazyClassRegister);
     Nan::Export(exports, "RegisterClass",        RegisterClass);
     Nan::Export(exports, "RegisterVFunc",        RegisterVFunc);
     Nan::Export(exports, "CallVFunc",            CallVFunc);

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -35,6 +35,11 @@ namespace GNodeJS {
 // Our base template for all GObjects
 static Nan::Persistent<FunctionTemplate> baseTemplate;
 
+// JS callback (registerClass) invoked to lazily register an unregistered JS
+// subclass the first time it is constructed. Installed via SetLazyClassRegister,
+// this makes registerClass() optional. Empty until JS installs it.
+static Nan::Persistent<Function> lazyClassRegister;
+
 
 static MaybeLocal<FunctionTemplate> GetClassTemplate(GType gtype);
 static MaybeLocal<Function>         GetClass(GType gtype);
@@ -221,11 +226,34 @@ static void GObjectConstructor(const FunctionCallbackInfo<Value> &info) {
 
     /* User code calling `new Gtk.Widget({ ... })` */
 
+    Local<Object> proto = Nan::To<Object>(self->GetPrototype()).ToLocalChecked();
+
+    /* A JS subclass (`class Foo extends Gtk.Widget {}`) that was never passed to
+     * registerClass() owns no GType: `__gtype__` is only *inherited* from its
+     * nearest registered ancestor, so constructing it as-is would silently
+     * instantiate that ancestor — losing the subtype and any vfunc overrides.
+     * Detect the missing *own* property and register the subclass on demand,
+     * which is what makes registerClass() optional. The JS callback installs an
+     * own `__gtype__` on `proto`, so the lookup below resolves to the
+     * freshly-registered subtype. */
+    if (!lazyClassRegister.IsEmpty()
+            && !Nan::HasOwnProperty(proto, UTF8("__gtype__")).FromMaybe(true)) {
+        Local<Function> registerFn = Nan::New<Function>(lazyClassRegister);
+        Local<Value> klass = Nan::Get(proto, UTF8("constructor")).ToLocalChecked();
+        Local<Value> argv[] = { klass };
+        Nan::TryCatch tryCatch;
+        Nan::Call(registerFn, Nan::GetCurrentContext()->Global(), 1, argv);
+        if (tryCatch.HasCaught()) {
+            tryCatch.ReThrow();
+            return;
+        }
+    }
+
     // FIXME: getting the gtype from the External is faster but doesn't
     // work for dynamically-registered types. Check if we can find something
     // better.
     //gtype = (GType) External::Cast(*info.Data())->Value();
-    gtype = GET_OBJECT_GTYPE (Nan::To<Object>(self->GetPrototype()).ToLocalChecked());
+    gtype = GET_OBJECT_GTYPE (proto);
 
     gobject = CreateGObjectFromObject (gtype, info[0]);
 
@@ -965,6 +993,10 @@ out:
     return result;
 }
 
+
+NAN_METHOD(SetLazyClassRegister) {
+    lazyClassRegister.Reset(info[0].As<Function>());
+}
 
 NAN_METHOD(RegisterClass) {
     auto jsKlassName  = Nan::To<String>(info[0]).ToLocalChecked();

--- a/src/gobject.h
+++ b/src/gobject.h
@@ -24,6 +24,7 @@ MaybeLocal<v8::Boolean> SetGObjectProperty   (GObject * gobject, const char *pro
 
 namespace ObjectClass {
 
+NAN_METHOD(SetLazyClassRegister);
 NAN_METHOD(RegisterClass);
 NAN_METHOD(RegisterVFunc);
 NAN_METHOD(CallVFunc);

--- a/tests/register-class__lazy.js
+++ b/tests/register-class__lazy.js
@@ -1,0 +1,92 @@
+/*
+ * register-class__lazy.js
+ *
+ * registerClass() is optional: the first `new Subclass()` of an unregistered JS
+ * subclass registers it on demand (see GObjectConstructor in src/gobject.cc).
+ * Without this, constructing an unregistered subclass would silently instantiate
+ * its nearest registered ancestor, losing the subtype and any vfunc overrides.
+ */
+
+const { describe, it, expect, skip } = require('./__common__')
+
+const gi = require('..')
+const GObject = gi.require('GObject')
+
+describe('registerClass (lazy)', () => {
+
+  it('registers a subclass on first construction, no registerClass() call', () => {
+    class LazyWidget extends GObject.Object {
+      static GTypeName = 'NodeGTKLazyWidget'
+    }
+
+    // No gi.registerClass(LazyWidget) here.
+    const w = new LazyWidget()
+
+    expect(w instanceof LazyWidget, true)
+    expect(w instanceof GObject.Object, true)
+    // The instance is the subtype, not the parent that __gtype__ is inherited from.
+    expect(GObject.typeName(w.__gtype__), 'NodeGTKLazyWidget')
+  })
+
+  it('lazily registers an unregistered ancestor chain', () => {
+    class LazyBase extends GObject.Object {
+      static GTypeName = 'NodeGTKLazyBase'
+    }
+    class LazySub extends LazyBase {
+      static GTypeName = 'NodeGTKLazySub'
+    }
+
+    // Construct the leaf without registering either class: both register.
+    const sub = new LazySub()
+
+    expect(sub instanceof LazyBase, true)
+    expect(GObject.typeName(sub.__gtype__), 'NodeGTKLazySub')
+    expect(GObject.typeFromName('NodeGTKLazyBase') !== GObject.TYPE_INVALID, true)
+  })
+
+  it('installs vfunc overrides through the lazy path', () => {
+    // chain-up (g_vfunc_info_invoke) crashes on macOS — see issue #453.
+    if (process.platform === 'darwin')
+      skip()
+
+    const order = []
+
+    class LazyA extends GObject.Object {
+      static GTypeName = 'NodeGTKLazyChainA'
+      constructed() {}                 // registers the override + parent bridge
+      chain() {
+        order.push('A:before')
+        super.constructed()            // -> native GObject.Object.constructed
+        order.push('A:after')
+      }
+    }
+    class LazyB extends LazyA {
+      static GTypeName = 'NodeGTKLazyChainB'
+      chain() {
+        order.push('B:before')
+        super.chain()                  // -> LazyA.prototype.chain
+        order.push('B:after')
+      }
+    }
+
+    // First construction registers both LazyB and LazyA (vfuncs included).
+    const b = new LazyB()
+    expect(typeof GObject.Object.prototype.constructed, 'function')
+
+    b.chain()
+    expect(order, ['B:before', 'A:before', 'A:after', 'B:after'])
+  })
+
+  it('a redundant registerClass() after construction is a no-op', () => {
+    class LazyIdempotent extends GObject.Object {
+      static GTypeName = 'NodeGTKLazyIdempotent'
+    }
+
+    const a = new LazyIdempotent()
+    // Already registered by construction; this must not throw "already registerd".
+    expect(gi.registerClass(LazyIdempotent), LazyIdempotent)
+    const b = new LazyIdempotent()
+
+    expect(a.__gtype__, b.__gtype__)
+  })
+})


### PR DESCRIPTION
## Summary

Makes `registerClass()` **optional**: the first `new MySubclass()` of an unregistered JS subclass now registers it on demand — including any unregistered ancestors — and installs its vfunc overrides. Most code no longer needs to call `registerClass` at all.

Previously, constructing a subclass you forgot to register silently instantiated its nearest *registered* ancestor (because `__gtype__` is only inherited), losing the subtype and any vfunc overrides — a quiet footgun. Now that case Just Works.

`registerClass()` stays in the public API for cases that need the GType **before** an instance exists (e.g. `getGType`, GtkBuilder templates referencing the type by name, using it as another type's property/child type). This change is backward compatible.

## How it works

- **Native (`src/gobject.cc`, `gobject.h`, `gi.cc`)** — `GObjectConstructor` detects a subclass whose prototype lacks an *own* `__gtype__` and invokes a JS hook installed via the new `SetLazyClassRegister` export. The hook sets the own `__gtype__`, so the existing gtype lookup then resolves to the freshly-registered subtype. Registration doesn't construct anything, so there's no re-entrancy. Native classes (own `__gtype__` on their prototype template) and already-registered JS classes skip the path entirely — no behavior change on the hot construction path.
- **JS (`lib/register-class.js`)** — installs the hook; `registerClass()` is now **idempotent** (returns early if already registered, so explicit + lazy can't double-register) and **recurses** over unregistered ancestors (the old code threw `Parent class not registered`). It now returns the class (usable as a decorator).
- **Docs/example** — `doc/api.md` + `CHANGELOG.md` mark it optional; the `registerClass(CustomWidget)` line is dropped from `examples/gtk-4-custom-widget.mjs`.

## Testing

- New `tests/register-class__lazy.js`: lazy single subclass, lazy ancestor chain, **vfunc overrides + `super` chain-up via the lazy path**, and redundant-`registerClass`-is-a-no-op. All pass.
- All pre-existing `register-class*` tests pass.
- Verified a real `Gtk.Widget` subclass constructs lazily with the correct subtype.
- Full suite: 68 passing, 19 pending, 1 failing — the failure is `require.js` (loads every system typelib; `Peas`/`PeasGtk` hit a `GIRepository 3.0` vs `2.0` conflict on the test machine), unrelated to this change.

## Notes / follow-ups

- Auto-registering every constructed subclass means a factory creating anonymous subclasses per-call would leak GTypes (GTypes are never freed) — same risk as explicit `registerClass`, just less visible.
- Could optionally also trigger lazy registration from `getGType()` so the type materializes on first *use* rather than first *construct*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)