### PR TITLE
feat(styles): dynamic render sheets + watch opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,11 @@ Changes to be released are kept in the unreleased section.
   It applies inline CSS (`styles.add`) and `.css` files (`styles.addFile`), and
   in development **hot-reloads** them as you edit, with no restart. Hot-reload
   is on when `NODE_ENV=development` (opt out with `NODE_GTK_STYLE_HOT_RELOAD=0`).
-  Ships with TypeScript types. See [Styles & hot-reload](./doc/styles.md).
+  `styles.add` also takes a `() => string` **render function** for dynamic CSS
+  built from live state, re-applied on hot-reload and via the handle's
+  `refresh()`; pass `{ watch: false }` to install a programmatic sheet without
+  watching its module. Ships with TypeScript types.
+  See [Styles & hot-reload](./doc/styles.md).
 - **App creator.** `node-gtk create <dir>` creates a ready-to-run TypeScript +
   ESM Adwaita app, with `style.css` wired through `node-gtk/styles` so it
   hot-reloads live under `npm run dev`. See

--- a/doc/styles.md
+++ b/doc/styles.md
@@ -41,14 +41,38 @@ app.on('activate', () => {
 | `styles.addFile(path)` | a `.css` stylesheet | re-reads the file into its provider |
 | `styles.add(css)` | inline CSS in a source module | re-imports that module (see the caveat below) |
 
-Both return a **handle** — `{ update(next), remove() }` — so you can replace or
-drop a sheet later from code:
+Both return a **handle** — `{ update(next), refresh(), remove() }` — so you can
+replace, re-apply, or drop a sheet later from code:
 
 ```javascript
 const sheet = styles.add(`label { color: red; }`)
 sheet.update(`label { color: green; }`)   // replace in place
 sheet.remove()                            // remove from the display
 ```
+
+## Dynamic stylesheets
+
+For CSS built from live state — a theme palette, the current fonts — pass a
+**render function** (`() => string`) to `styles.add` instead of a string. It runs
+immediately, again on every hot-reload of its module (so editing the
+CSS-generating code re-applies it), and on demand when you call the handle's
+`refresh()` — which you do whenever the state it reads changes:
+
+```javascript
+const sheet = styles.add(() => `:root { --accent: ${theme.accent}; }`)
+// ...later, when the theme changes:
+theme.onChange(() => sheet.refresh())     // re-runs the render
+```
+
+`refresh()` re-applies a sheet from its current source (re-running the render, or
+re-reading a `.css` file). `update(css)` instead pins the sheet to a fixed string,
+dropping any render function.
+
+A render function still lives in a module that a reload re-imports, so the same
+side-effect-free rule applies (below). When the dynamic CSS is owned by a
+**stateful** module that can't be re-imported safely — its `add` runs inside a
+method, or it owns a singleton with listeners — pass `{ watch: false }` so it
+installs without being watched; you re-apply it yourself via `refresh()`.
 
 ## When styles install
 
@@ -109,9 +133,9 @@ demo of both reload paths.
 
 | Member | Description |
 | --- | --- |
-| `styles.add(css, { priority? })` | Inline CSS; hot-reloads via module re-import. Returns a handle. |
+| `styles.add(css, { priority?, watch? })` | Inline CSS, or a `() => string` render function; hot-reloads via module re-import. `watch: false` opts out of watching. Returns a handle. |
 | `styles.addFile(path, { priority?, watch? })` | A `.css` file (string, `file://` URL, or `URL`); hot-reloads by re-reading. Idempotent per path. Returns a handle. |
 | `styles.install()` | Install queued styles and start the watcher. |
 
-The handle returned by `add` / `addFile` is `{ update(next), remove() }`.
+The handle returned by `add` / `addFile` is `{ update(next), refresh(), remove() }`.
 `StyleManager` (the class) and the shared `styles` instance are the only exports.

--- a/lib/styles.d.ts
+++ b/lib/styles.d.ts
@@ -11,6 +11,17 @@ export interface StyleOptions {
   priority?: number
 }
 
+/** Options for {@link StyleManager.add}. */
+export interface StyleAddOptions extends StyleOptions {
+  /**
+   * Watch the calling module for hot-reload (defaults to on in development).
+   * Pass `false` for a programmatic sheet whose source can't be re-imported
+   * safely (built inside a method, or owned by a stateful module); the handle
+   * still supports `update`/`refresh`/`remove`.
+   */
+  watch?: boolean
+}
+
 /** Options for {@link StyleManager.addFile}. */
 export interface StyleFileOptions extends StyleOptions {
   /** Watch the file for hot-reload (defaults to on in development). */
@@ -19,8 +30,17 @@ export interface StyleFileOptions extends StyleOptions {
 
 /** A handle to an installed (or queued) stylesheet. */
 export interface StyleSheet {
-  /** Replace the CSS (or, for a file sheet, re-read the path) in place. */
+  /**
+   * Replace the CSS (or, for a file sheet, re-read the path) in place. For an
+   * inline sheet a string replaces any render function — it becomes fixed CSS.
+   */
   update(next: string): void
+  /**
+   * Re-apply the sheet from its current source: re-run the render function
+   * (inline) or re-read the path (file). Call it when the state a render reads
+   * changes. A no-op for a queued sheet (not yet installed).
+   */
+  refresh(): void
   /** Remove the sheet from the display. */
   remove(): void
 }
@@ -33,9 +53,15 @@ export interface StyleSheet {
 export declare class StyleManager {
   /**
    * Queue (or, once the display exists, install) inline CSS. The source file it
-   * is called from is watched for hot-reload.
+   * is called from is watched for hot-reload (unless `watch` is false).
+   *
+   * `css` may be a `() => string` *render* function instead of a string, for a
+   * dynamic stylesheet built from live state (theme, fonts, …). The render runs
+   * now and again on every hot-reload of its module, and on demand via the
+   * handle's {@link StyleSheet.refresh}. Keep such a module side-effect-free at
+   * its top level (a re-import re-runs it).
    */
-  add(css: string, options?: StyleOptions): StyleSheet
+  add(css: string | (() => string), options?: StyleAddOptions): StyleSheet
 
   /**
    * Queue (or install) a `.css` file. Unless `watch` is false, the file is

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -87,7 +87,8 @@ function frameFile(frame) {
 /**
  * A handle to an installed (or queued) stylesheet.
  * @typedef {object} StyleSheet
- * @property {(next: string) => void} update   Replace the CSS in place.
+ * @property {(next: string) => void} update   Replace with fixed CSS (drops any render fn).
+ * @property {() => void} refresh              Re-apply from source (re-run render / re-read file).
  * @property {() => void} remove               Remove the sheet from the display.
  */
 
@@ -112,13 +113,36 @@ class StyleManager {
   /**
    * Inline CSS, hot-reloaded by re-importing its source module. Queued until the
    * display exists.
-   * @param {string} css
-   * @param {{ priority?: number }} [options]
+   *
+   * `css` may be a `() => string` *render* function instead of a string, for
+   * dynamic stylesheets built from live state (theme, fonts, …). The render runs
+   * now and again on every hot-reload of its module (so editing the
+   * CSS-generating code re-applies it), and on demand via the handle's
+   * `refresh()` — call it whenever the state it reads changes. Keep such a module
+   * side-effect-free at its top level (a re-import re-runs it); a stateful
+   * singleton it owns must survive re-import (e.g. guarded on `globalThis`).
+   *
+   * Pass `watch: false` to install without watching the caller for hot-reload —
+   * for programmatic sheets whose source can't be re-imported safely (created
+   * inside a method, owned by a stateful module). The handle still supports
+   * `update`/`refresh`/`remove`.
+   * @param {string | (() => string)} css  Inline CSS, or a render function.
+   * @param {{ priority?: number, watch?: boolean }} [options]
    * @returns {StyleSheet}
    */
   add(css, options = {}) {
-    const file = HOT_RELOAD ? callerFile() : null
-    const entry = { kind: 'inline', css, file, priority: options.priority, provider: null, cancelled: false }
+    const render = typeof css === 'function' ? css : null
+    const watch = HOT_RELOAD && (options.watch ?? true)
+    const file = watch ? callerFile() : null
+    const entry = {
+      kind: 'inline',
+      render,
+      css: render ? null : css,
+      file,
+      priority: options.priority,
+      provider: null,
+      cancelled: false,
+    }
     this.place(entry)
     if (file) this.watch(file)
     return this.handle(entry)
@@ -185,7 +209,7 @@ class StyleManager {
       entry.provider = provider
     } else {
       const provider = this.newProvider()
-      loadCss(provider, entry.css)
+      loadCss(provider, entry.render ? entry.render() : entry.css)
       this.addProvider(provider, entry.priority)
       entry.provider = provider
       if (entry.file) this.trackFileProvider(entry.file, provider)
@@ -233,9 +257,19 @@ class StyleManager {
           }
           if (entry.provider) entry.provider.loadFromPath(entry.path)
         } else {
+          // A literal replaces a render function: from now on this is fixed CSS.
+          entry.render = null
           entry.css = next
           if (entry.provider) loadCss(entry.provider, next)
         }
+      },
+      // Re-apply the sheet from its current source: re-run the render function
+      // (inline) or re-read the path (file). For a fixed-string inline sheet this
+      // just re-loads the same CSS. Use it when the state a render reads changes.
+      refresh: () => {
+        if (!entry.provider) return
+        if (entry.kind === 'file') entry.provider.loadFromPath(entry.path)
+        else loadCss(entry.provider, entry.render ? entry.render() : entry.css)
       },
       remove: () => {
         if (entry.cancelled) return

--- a/tests/style_manager.js
+++ b/tests/style_manager.js
@@ -73,6 +73,33 @@ describe('StyleManager', () => {
     file.update(tmpCss)
     file.remove()
   })
+
+  it('add(renderFn) runs the render at install and again on refresh()', () => {
+    const styles = new StyleManager()
+    let calls = 0
+    const sheet = styles.add(() => `.r { color: red; } /* ${++calls} */`)
+    expect(calls, 1) // rendered once at install
+    sheet.refresh()
+    expect(calls, 2) // refresh re-runs the render
+  })
+
+  it('update() with a string drops the render fn (literal wins)', () => {
+    const styles = new StyleManager()
+    let calls = 0
+    const sheet = styles.add(() => { calls++; return '.a { color: red; }' })
+    expect(calls, 1)
+    sheet.update('.b { color: green; }') // now fixed CSS
+    sheet.refresh()
+    expect(calls, 1) // render no longer invoked
+  })
+
+  it('watch:false installs without watching the caller', () => {
+    const styles = new StyleManager()
+    styles.add('.q { color: red; }', { watch: false })
+    expect(styles.watchedFiles.size, 0)
+    styles.add('.w { color: red; }') // default: watched
+    expect(styles.watchedFiles.size, 1)
+  })
 })
 
 function isntNull(value) {


### PR DESCRIPTION
## Summary

Extends the (still-unreleased) `node-gtk/styles` `StyleManager` so apps can drive **dynamic, hot-reloadable** stylesheets — CSS built from live state (theme palettes, fonts) — not just static inline strings and `.css` files. Surfaced while dogfooding `node-gtk/styles` in zym, whose font and theme-chrome sheets are computed at runtime.

## What's new

- **Render functions.** `styles.add(() => string)` accepts a render function. It runs at install, re-runs on each hot-reload of its module, and on demand via the handle.
- **`handle.refresh()`.** Re-applies a sheet from its current source — re-run the render function (inline) or re-read the path (file). Call it when the state a render reads changes (e.g. on `theme.onChange`). `update(css)` still pins a sheet to a fixed string, now also dropping any render function.
- **`add({ watch: false })`.** Installs an inline sheet without watching its module for hot-reload — for programmatic sheets whose source can't be safely re-imported (built inside a method, or owned by a stateful singleton with listeners). Symmetric with the existing `addFile({ watch })`. The handle still supports `update`/`refresh`/`remove`.

## Notes

- Fully backward-compatible: `add(string)` is unchanged; the only behavioral tweak is `update(string)` now clears a render function (a no-op for existing string-only sheets).
- Tests added in `tests/style_manager.js`; `doc/styles.md`, `lib/styles.d.ts`, and the CHANGELOG entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)