### PR TITLE
fix: return null for nullable char*/array returns at EOF (#467)

### DIFF
--- a/src/function.cc
+++ b/src/function.cc
@@ -708,7 +708,8 @@ Local<Value> FunctionInfo::JsReturnValue (
         ADD_RETURN (isReturningSelf ? self :
             GIArgumentToV8 (
                 return_type, return_value, length,
-                return_transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone))
+                return_transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone,
+                g_callable_info_may_return_null (info)))
     }
 
     for (int i = 0; i < n_callable_args; i++) {
@@ -742,20 +743,22 @@ Local<Value> FunctionInfo::JsReturnValue (
                         &callable_arg_values[length_i],
                         IsDirectionOut(length_direction));
 
-                Local<Value> result = ArrayToV8(&arg_type, *(void**)arg_value.v_pointer, param.length);
+                bool may_be_null = g_arg_info_may_be_null(&arg_info);
+                Local<Value> result = ArrayToV8(&arg_type, *(void**)arg_value.v_pointer, param.length, may_be_null);
 
                 ADD_RETURN (result)
 
             } else if (param.type == ParameterType::kNORMAL) {
                 GITransfer transfer = g_arg_info_get_ownership_transfer(&arg_info);
                 ResourceOwnership ownership = transfer == GI_TRANSFER_EVERYTHING ? kTransfer : kNone;
+                bool may_be_null = g_arg_info_may_be_null(&arg_info);
 
                 if (IsPointerType(&arg_type) && g_arg_info_is_caller_allocates(&arg_info)) {
                     void *pointer = &arg_value.v_pointer;
-                    ADD_RETURN (GIArgumentToV8(&arg_type, (GIArgument*) pointer, -1, ownership))
+                    ADD_RETURN (GIArgumentToV8(&arg_type, (GIArgument*) pointer, -1, ownership, may_be_null))
                 }
                 else {
-                    ADD_RETURN (GIArgumentToV8(&arg_type, (GIArgument*) arg_value.v_pointer, -1, ownership))
+                    ADD_RETURN (GIArgumentToV8(&arg_type, (GIArgument*) arg_value.v_pointer, -1, ownership, may_be_null))
                 }
             }
         }

--- a/src/value.cc
+++ b/src/value.cc
@@ -51,7 +51,7 @@ static guint64 V8ToUint64 (Local<Value> value) {
 }
 
 
-Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length, ResourceOwnership ownership) {
+Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length, ResourceOwnership ownership, bool nullable) {
     GITypeTag type_tag = g_type_info_get_tag (type_info);
 
     switch (type_tag) {
@@ -120,6 +120,11 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
     case GI_TYPE_TAG_UTF8: {
         if (arg->v_string)
             return New<String>(arg->v_string).ToLocalChecked();
+        else if (nullable)
+            // A nullable string (e.g. g_data_input_stream_read_line_utf8_finish
+            // at EOF) returns NULL: surface it as `null` so it is
+            // distinguishable from a legitimately empty string. (#467)
+            return Nan::Null();
         else
             return Nan::EmptyString();
     }
@@ -166,7 +171,7 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
         }
 
     case GI_TYPE_TAG_ARRAY:
-        return ArrayToV8(type_info, arg->v_pointer, length);
+        return ArrayToV8(type_info, arg->v_pointer, length, nullable);
 
     case GI_TYPE_TAG_GLIST:
         return GListToV8(type_info, (GList *)arg->v_pointer);
@@ -323,7 +328,13 @@ static bool IsZeroMemory (const void *ptr, gsize size) {
     return true;
 }
 
-Local<Value> ArrayToV8 (GITypeInfo *type_info, void* data, long length) {
+Local<Value> ArrayToV8 (GITypeInfo *type_info, void* data, long length, bool nullable) {
+
+    // A nullable array return (e.g. g_data_input_stream_read_line_finish at
+    // EOF) yields a NULL pointer: surface it as `null` so it is
+    // distinguishable from a legitimately empty array. (#467)
+    if (data == nullptr && nullable)
+        return Nan::Null();
 
     auto array = New<Array>();
 

--- a/src/value.h
+++ b/src/value.h
@@ -20,9 +20,9 @@ enum ResourceOwnership {
 Local<Value> GListToV8  (GITypeInfo *info, GList  *glist);
 Local<Value> GSListToV8 (GITypeInfo *info, GSList *glist);
 Local<Value> GHashToV8 (GITypeInfo *info, GHashTable *hash);
-Local<Value> ArrayToV8  (GITypeInfo *info, gpointer data, long length = -1);
+Local<Value> ArrayToV8  (GITypeInfo *info, gpointer data, long length = -1, bool nullable = false);
 Local<Value> GErrorToV8 (GITypeInfo *type_info, GError *err, ResourceOwnership ownership = kNone);
-Local<Value> GIArgumentToV8 (GITypeInfo *type_info, GIArgument *argument, long length = -1, ResourceOwnership ownership = kNone);
+Local<Value> GIArgumentToV8 (GITypeInfo *type_info, GIArgument *argument, long length = -1, ResourceOwnership ownership = kNone, bool nullable = false);
 long         GIArgumentToLength(GITypeInfo *type_info, GIArgument *arg, bool is_pointer);
 
 bool         V8ToGIArgumentInterface (GIBaseInfo *gi_info, GIArgument *argument, Local<Value> value);

--- a/tests/conversion__nullable_array_eof.js
+++ b/tests/conversion__nullable_array_eof.js
@@ -1,0 +1,57 @@
+/*
+ * conversion__nullable_array_eof.js
+ *
+ * A nullable `char*`/byte-array return (annotated `nullable="1"` in the GIR)
+ * must surface a NULL C pointer as JS `null`, not as an empty array/string, so
+ * that end-of-stream stays distinguishable from a legitimately empty line.
+ * Regression test for #467.
+ */
+
+const gi = require('../lib/')
+const GLib = gi.require('GLib')
+const Gio = gi.require('Gio')
+const { describe, expect } = require('./__common__.js')
+
+function makeStream(text) {
+  const bytes = GLib.Bytes.new([...Buffer.from(text)])
+  return Gio.DataInputStream.new(Gio.MemoryInputStream.newFromBytes(bytes))
+}
+
+describe('read_line: EOF is null, empty line is []', () => {
+  // "a\n\nb\n" => "a", "" (empty line), "b", then EOF
+  const dis = makeStream('a\n\nb\n')
+
+  const [l0] = dis.readLine(null)
+  expect(l0, [0x61]) // "a"
+
+  const [l1] = dis.readLine(null)
+  expect(l1, []) // empty line — genuinely empty, NOT eof
+
+  const [l2] = dis.readLine(null)
+  expect(l2, [0x62]) // "b"
+
+  const [eof] = dis.readLine(null)
+  expect(eof, null) // end-of-stream is null, not []
+})
+
+describe('read_line: empty stream reads null immediately', () => {
+  const dis = makeStream('')
+  const [eof] = dis.readLine(null)
+  expect(eof, null)
+})
+
+describe('read_line_utf8: EOF is null, empty line is ""', () => {
+  const dis = makeStream('a\n\nb\n')
+
+  const [l0] = dis.readLineUtf8(null)
+  expect(l0, 'a')
+
+  const [l1] = dis.readLineUtf8(null)
+  expect(l1, '') // empty line — genuinely empty, NOT eof
+
+  const [l2] = dis.readLineUtf8(null)
+  expect(l2, 'b')
+
+  const [eof] = dis.readLineUtf8(null)
+  expect(eof, null) // end-of-stream is null, not ""
+})


### PR DESCRIPTION
Fixes #467.

## Problem

`g_data_input_stream_read_line_finish()` (and friends) return `NULL` at end-of-stream. node-gtk mapped that `NULL` to an empty JS array `[]` — and the UTF-8 finishers mapped it to an empty string `""` — so **EOF was indistinguishable from a legitimately empty line**. Code streaming a newline-delimited protocol had to special-case zero-length as EOF and could never emit genuine blank lines.

```
buf = [97]  len = 1
buf = [98]  len = 1
buf = []    len = 0        <-- EOF, but returned [] instead of null
```

## Fix

Thread the GIR nullability annotation into the GI→JS conversion:

- return values use `g_callable_info_may_return_null()`
- out-arguments use `g_arg_info_may_be_null()`

`ArrayToV8` / `GIArgumentToV8` now surface a `NULL` C pointer as JS `null` **only when the return/out-arg is actually annotated nullable**. Non-nullable returns keep the existing empty-array / empty-string behavior, so a genuinely empty line still reads back as `[]` / `""`.

This covers both the byte-array finishers (`read_line`, `read_line_finish`) and the UTF-8 finishers (`read_line_utf8`, `read_line_utf8_finish`), matching the documented `NULL` return of GLib.

## Verification

Repro from the issue now prints:

```
buf = [97]  len = 1
buf = [98]  len = 1
buf = null  len = 0        <-- EOF
```

And the empty-line vs EOF distinction is preserved (`"a\n\nb\n"` → `[97]`, `[]`, `[98]`, `null`).

Added `tests/conversion__nullable_array_eof.js` covering byte-array and UTF-8 variants (EOF → `null`, empty line → `[]`/`""`, empty stream → immediate `null`).

Full suite: **93 passing**, no new failures. (`require.js` fails identically on `master` — a pre-existing, environment-specific GIRepository 3.0/2.0 version conflict unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)