### PR TITLE
fix: marshal GVariant into signal handlers as a refcounted value (#465)

### DIFF
--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -190,7 +190,14 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
         boxed = External::Cast(*info[0])->Value();
 
         if (ownership == kCopy) {
-            if (gtype != G_TYPE_NONE) {
+            if (gtype == G_TYPE_VARIANT) {
+                // GVariant is a refcounted fundamental type, not a boxed type:
+                // g_boxed_copy would fail its G_TYPE_IS_BOXED assertion and
+                // return NULL, leaving the wrapper pointing at garbage (#465).
+                // Take our own reference instead.
+                boxed = g_variant_ref ((GVariant *) boxed);
+            }
+            else if (gtype != G_TYPE_NONE) {
                 boxed = g_boxed_copy (gtype, boxed);
             }
             else if ((size = Boxed::GetSize(gi_info)) != 0) {
@@ -247,6 +254,12 @@ static void BoxedConstructor(const Nan::FunctionCallbackInfo<Value> &info) {
             Nan::ThrowError("Boxed allocation failed");
             return;
         }
+
+        // A freshly constructed GVariant is typically floating; take a full,
+        // non-floating reference so the wrapper owns it and can g_variant_unref
+        // it on finalize without stealing anyone else's reference (#465).
+        if (gtype == G_TYPE_VARIANT)
+            boxed = g_variant_take_ref ((GVariant *) boxed);
     }
 
     Boxed *box = new Boxed();
@@ -275,7 +288,12 @@ static void BoxedDestroyed(const Nan::WeakCallbackInfo<Boxed> &info) {
      * such as Typelib and BaseInfo.
      */
     if (box->owns_memory) {
-        if (G_TYPE_IS_BOXED(box->gtype)) {
+        if (box->gtype == G_TYPE_VARIANT) {
+            // Refcounted fundamental type, not boxed: release our reference (#465).
+            if (box->data != NULL)
+                g_variant_unref ((GVariant *) box->data);
+        }
+        else if (G_TYPE_IS_BOXED(box->gtype)) {
             g_boxed_free(box->gtype, box->data);
         }
         else if (box->size != 0) {

--- a/src/value.cc
+++ b/src/value.cc
@@ -1616,6 +1616,19 @@ static GType BoxedGTypeOf (GITypeInfo *type_info) {
     return gtype;
 }
 
+// Returns TRUE if `type_info` is the GVariant fundamental type. GVariant is a
+// GI struct whose registered GType is G_TYPE_VARIANT, but it is refcounted
+// rather than boxed, so it needs g_variant_ref/unref instead of g_boxed_*.
+static bool IsVariantTypeInfo (GITypeInfo *type_info) {
+    if (g_type_info_get_tag(type_info) != GI_TYPE_TAG_INTERFACE)
+        return false;
+
+    GIBaseInfo *interface_info = g_type_info_get_interface(type_info);
+    GType gtype = g_registered_type_info_get_g_type(interface_info);
+    g_base_info_unref(interface_info);
+    return gtype == G_TYPE_VARIANT;
+}
+
 void CopyBoxedForTransferFullIn (GITypeInfo *type_info, GIArgument *arg, long length) {
     if (arg->v_pointer == NULL)
         return;
@@ -1627,6 +1640,10 @@ void CopyBoxedForTransferFullIn (GITypeInfo *type_info, GIArgument *arg, long le
         GType gtype = BoxedGTypeOf(type_info);
         if (gtype != G_TYPE_INVALID)
             arg->v_pointer = g_boxed_copy(gtype, arg->v_pointer);
+        else if (IsVariantTypeInfo(type_info))
+            // GVariant is refcounted, not boxed: give the callee its own
+            // reference so the JS wrapper isn't unref'd out from under it (#465).
+            arg->v_pointer = g_variant_ref((GVariant *) arg->v_pointer);
         return;
     }
 
@@ -1726,7 +1743,7 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         return false;
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        return false;
+        return value->IsNullOrUndefined() || ValueIsInstanceOfGType(value, G_TYPE_VARIANT);
     }
 
     ERROR("Unhandled GValue type: %s (please report this)",
@@ -1819,7 +1836,9 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership)
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         ERROR("Unsupported type: pointer");
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        ERROR("Unsupported type: variant");
+        // g_value_set_variant refs the variant (and sinks a floating one), so
+        // the GValue holds its own reference independent of the JS wrapper (#465).
+        g_value_set_variant (gvalue, (GVariant *) PointerFromWrapper (value));
     } else {
         ERROR("Unhandled GValue type: %s (please report this)",
                 g_type_name(G_VALUE_TYPE(gvalue)));
@@ -1896,7 +1915,15 @@ Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         ERROR("Unsuported type: pointer");
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        ERROR("Unsuported type: variant");
+        GVariant *variant = g_value_get_variant (gvalue);
+        if (variant == NULL)
+            return Nan::Null();
+        // GVariant is refcounted, not boxed; WrapperFromBoxed with kCopy takes
+        // its own reference via g_variant_ref (see BoxedConstructor, #465).
+        GIBaseInfo *info = g_irepository_find_by_gtype (NULL, G_TYPE_VARIANT);
+        Local<Value> obj = WrapperFromBoxed (info, variant, ownership);
+        g_base_info_unref (info);
+        return obj;
     } else {
         // Don't abort the whole process on a GValue type we can't convert
         // (e.g. GStreamer's GstValueArray / GstValueList, #389). Warn and

--- a/tests/signal__variant.js
+++ b/tests/signal__variant.js
@@ -1,0 +1,92 @@
+/*
+ * signal__variant.js
+ *
+ * A GVariant marshalled INTO a signal handler (e.g. the parameter of
+ * Gio.SimpleAction::activate / ::change-state) must arrive as a valid,
+ * readable variant, not a wrapper pointing at NULL (#465). GVariant is a
+ * refcounted fundamental type, not a boxed type, so it needs
+ * g_variant_ref/unref rather than g_boxed_copy/free.
+ */
+
+const gi = require('../lib/')
+const GLib = gi.require('GLib', '2.0')
+const Gio = gi.require('Gio', '2.0')
+const { describe, it, assert, expect } = require('./__common__.js')
+
+const gc = global.gc || (() => {})
+
+describe('GVariant passed into a signal handler', () => {
+
+  it('is readable inside the handler (the #465 repro)', () => {
+    const action = Gio.SimpleAction.new('t', GLib.VariantType.new('s'))
+    let seen = null
+    action.on('activate', (parameter) => {
+      seen = parameter.getString()[0]
+    })
+
+    const v = GLib.Variant.newString('hello-world')
+    expect(v.getString()[0], 'hello-world')  // JS-side read
+    action.activate(v)
+    expect(seen, 'hello-world')              // read inside the handler
+  })
+
+  it('gives the handler its own reference that outlives the emission', () => {
+    const action = Gio.SimpleAction.new('u', GLib.VariantType.new('s'))
+    let captured = null
+    action.on('activate', (parameter) => { captured = parameter })
+
+    action.activate(GLib.Variant.newString('kept-alive'))
+    gc()
+
+    assert(captured instanceof GLib.Variant, 'captured is a GLib.Variant')
+    expect(captured.getString()[0], 'kept-alive')
+  })
+
+  it('carries the requested value into ::change-state', () => {
+    const action = Gio.SimpleAction.newStateful(
+      's', GLib.VariantType.new('s'), GLib.Variant.newString('a'))
+    let requested = null
+    action.on('change-state', (value) => {
+      requested = value.getString()[0]
+      action.setState(value)  // exercises writing a variant back out (V8ToGValue)
+    })
+
+    action.changeState(GLib.Variant.newString('b'))
+    expect(requested, 'b')
+    expect(action.getState().getString()[0], 'b')
+  })
+
+  it('does not leak or double-free across many round-trips + GC', () => {
+    const action = Gio.SimpleAction.new('r', GLib.VariantType.new('s'))
+    let seen = null
+    action.on('activate', (parameter) => { seen = parameter.getString()[0] })
+
+    for (let i = 0; i < 2000; i++) {
+      action.activate(GLib.Variant.newString('value-' + i))
+      expect(seen, 'value-' + i)
+      if (i % 100 === 0)
+        gc()
+    }
+    gc()
+  })
+})
+
+describe('GVariant as a GObject property', () => {
+
+  it('reads back through the GValue path (GValueToV8)', () => {
+    const action = Gio.SimpleAction.newStateful(
+      'g', GLib.VariantType.new('s'), GLib.Variant.newString('hello'))
+    assert(action.state instanceof GLib.Variant, 'state is a GLib.Variant')
+    expect(action.state.getString()[0], 'hello')
+  })
+
+  it('sets at construction through the GValue path (V8ToGValue)', () => {
+    const action = new Gio.SimpleAction({
+      name: 'c',
+      state: GLib.Variant.newString('constructed'),
+    })
+    expect(action.state.getString()[0], 'constructed')
+    gc()
+    expect(action.state.getString()[0], 'constructed')
+  })
+})


### PR DESCRIPTION
Fixes #465.

## Problem

A `GVariant` that GTK passes **into** a JS signal handler (e.g. the `parameter` of `Gio.SimpleAction::activate`, or the value of `::change-state`) arrived corrupted — reading it emitted criticals and returned garbage:

```
(GLib-GObject-CRITICAL): g_boxed_copy: assertion 'G_TYPE_IS_BOXED (boxed_type)' failed
(GLib-CRITICAL):         g_variant_get_string: assertion 'value != NULL' failed
```

## Cause

`GVariant` is a **refcounted fundamental type** (`G_TYPE_VARIANT`), not a boxed type. The `Boxed` wrapper treated it as boxed and, when copying an incoming value (`ResourceOwnership::kCopy`), called `g_boxed_copy(G_TYPE_VARIANT, …)`. That fails the `G_TYPE_IS_BOXED` assertion and returns `NULL`, so the JS wrapper ended up pointing at `NULL` → garbage on read.

## Fix

Special-case `G_TYPE_VARIANT` throughout the `Boxed` lifecycle and the `GValue` conversions so it is reference-counted with `g_variant_ref`/`g_variant_unref`:

- **`BoxedConstructor`** — `g_variant_ref` on copy-in (instead of the failing `g_boxed_copy`); `g_variant_take_ref` on construction so the wrapper owns the typically-floating new reference.
- **`BoxedDestroyed`** — `g_variant_unref` on finalize (previously variants just `WARN`'d and leaked).
- **`CopyBoxedForTransferFullIn`** — `g_variant_ref` for a transfer-full `IN` argument, so the callee gets its own reference and the JS wrapper isn't unref'd out from under it (avoids a double-free now that finalize unrefs).
- **`GValueToV8` / `V8ToGValue` / `CanConvertV8ToGValue`** — read/write variants through the `GValue` path (non-introspected signals, GObject properties) instead of aborting via `g_assert_not_reached()`.

The reference counting is balanced end-to-end: create → `activate` → re-read in the handler → GC leaves no leak and no double-free.

## Tests

New `tests/signal__variant.js` covers:
- the exact issue repro (read `parameter.getString()` inside an `activate` handler),
- the handler receiving its own reference that outlives the emission,
- `::change-state` carrying the requested value,
- a 2000-iteration round-trip + GC stress loop (would crash on a double-free or grow on a leak),
- `GVariant` GObject properties round-tripping through the `GValue` path.

## Verification

- The issue's minimal repro now prints `hello-world` inside the handler with no criticals.
- Full suite: `93 passing`, plus the new test. The single failing `require.js` is a pre-existing, unrelated environment issue (loading every system typelib hits a `GIRepository 2.0` vs `3.0` conflict via Peas) — it fails identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)