### PR TITLE
fix: wrap GskRenderNode and other fundamental types correctly (#468)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,7 @@
                 "src/debug.cc",
                 "src/error.cc",
                 "src/function.cc",
+                "src/fundamental.cc",
                 "src/gi.cc",
                 "src/gobject.cc",
                 "src/loop.cc",

--- a/src/boxed.cc
+++ b/src/boxed.cc
@@ -6,6 +6,7 @@
 #include "debug.h"
 #include "error.h"
 #include "function.h"
+#include "fundamental.h"
 #include "gi.h"
 #include "gobject.h"
 #include "macros.h"
@@ -413,6 +414,13 @@ Local<Function> GetBoxedFunction(GIBaseInfo *info, GType gtype) {
 
 Local<Function> MakeBoxedClass(GIBaseInfo *info) {
     GType gtype = g_registered_type_info_get_g_type ((GIRegisteredTypeInfo *) info);
+
+    // GVariant is a StructInfo but a refcounted fundamental (G_TYPE_VARIANT),
+    // not a boxed value: give it the fundamental ref/unref wrapper instead of
+    // the boxed copy/free one. JS still attaches its struct methods to this
+    // class via makeBoxed() (#465).
+    if (gtype == G_TYPE_VARIANT)
+        return MakeVariantClass (info);
 
     if (gtype == G_TYPE_NONE) {
         auto moduleCache = GNodeJS::GetModuleCache();

--- a/src/function.cc
+++ b/src/function.cc
@@ -530,6 +530,7 @@ Local<Value> FunctionCall (
                     CopyBoxedForTransferFullIn(&type_info, &callable_arg_values[i], param.length);
                     RefObjectForTransferFullIn(&type_info, &callable_arg_values[i]);
                     RefFundamentalForTransferFullIn(&type_info, &callable_arg_values[i]);
+                    RefVariantForTransferFullIn(&type_info, &callable_arg_values[i]);
                 }
             }
 

--- a/src/function.cc
+++ b/src/function.cc
@@ -5,6 +5,7 @@
 #include "callback.h"
 #include "debug.h"
 #include "error.h"
+#include "fundamental.h"
 #include "function.h"
 #include "gobject.h"
 #include "macros.h"
@@ -522,11 +523,13 @@ Local<Value> FunctionCall (
                 // Boxed: hand it a copy so the JS wrapper's own memory isn't
                 // double-freed when finalized (#409). GObject: add the reference
                 // the callee will own, so it isn't finalized out from under the
-                // callee once the wrapper is GC'd (#439).
+                // callee once the wrapper is GC'd (#439). Fundamental (e.g.
+                // GskRenderNode): add the reference the callee will own (#468).
                 else if (direction == GI_DIRECTION_IN
                         && g_arg_info_get_ownership_transfer(&arg_info) == GI_TRANSFER_EVERYTHING) {
                     CopyBoxedForTransferFullIn(&type_info, &callable_arg_values[i], param.length);
                     RefObjectForTransferFullIn(&type_info, &callable_arg_values[i]);
+                    RefFundamentalForTransferFullIn(&type_info, &callable_arg_values[i]);
                 }
             }
 

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -161,7 +161,7 @@ static void FundamentalConstructor (const Nan::FunctionCallbackInfo<Value> &info
     instance->persistent = new Persistent<Object> (self);
     instance->persistent->SetWeak (instance, FundamentalDestroyed, WeakCallbackType::kParameter);
 
-    self->SetAlignedPointerInInternalField (0, ptr);
+    Nan::SetInternalFieldPointer (self, 0, ptr);
     SET_OBJECT_GTYPE (self, gtype);
 }
 
@@ -174,7 +174,7 @@ static void FundamentalToString (const Nan::FunctionCallbackInfo<Value> &info) {
     }
 
     GType gtype = GET_OBJECT_GTYPE (self);
-    void *address = self->GetAlignedPointerFromInternalField (0);
+    void *address = Nan::GetInternalFieldPointer (self, 0);
     char *str = g_strdup_printf ("[%s %#zx]", g_type_name (gtype), (size_t) address);
     info.GetReturnValue ().Set (UTF8 (str));
     g_free (str);
@@ -377,7 +377,7 @@ static void VariantConstructor (const Nan::FunctionCallbackInfo<Value> &info) {
     instance->persistent = new Persistent<Object> (self);
     instance->persistent->SetWeak (instance, FundamentalDestroyed, WeakCallbackType::kParameter);
 
-    self->SetAlignedPointerInInternalField (0, ptr);
+    Nan::SetInternalFieldPointer (self, 0, ptr);
     SET_OBJECT_GTYPE (self, G_TYPE_VARIANT);
 }
 

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -1,0 +1,306 @@
+/*
+ * fundamental.cc
+ *
+ * See fundamental.h. Wraps fundamental (non-GObject) ref-counted types such as
+ * GskRenderNode. The wrapper owns exactly one reference (taken via the type's
+ * introspected ref function, or adopted from a transfer-full return) and drops
+ * it on garbage collection via the unref function. Unlike GObject wrappers this
+ * uses no toggle-ref / qdata / weak-ref machinery — a fundamental type is not a
+ * GObject and those calls would fail their G_IS_OBJECT assertions (#468).
+ */
+
+#include <girepository.h>
+#include <glib.h>
+
+#include "fundamental.h"
+#include "gi.h"
+#include "macros.h"
+#include "util.h"
+#include "value.h"
+
+using v8::External;
+using v8::FunctionTemplate;
+using v8::Isolate;
+using v8::Object;
+using Nan::New;
+using Nan::Persistent;
+using Nan::WeakCallbackType;
+
+namespace GNodeJS {
+
+/* Per-instance bookkeeping so the GC weak callback can drop our reference. */
+struct FundamentalInstance {
+    void *data;
+    GIObjectInfoUnrefFunction unref;
+    Persistent<Object> *persistent;
+};
+
+bool IsFundamentalObjectInfo (GIObjectInfo *info) {
+    if (g_base_info_get_type (info) != GI_INFO_TYPE_OBJECT)
+        return false;
+    if (!g_object_info_get_fundamental (info))
+        return false;
+
+    /* GParamSpec is also a fundamental (non-GObject) type, but it has its own
+     * dedicated wrapper (param_spec.cc) that predates this one and is used by
+     * the value.cc / V8ToGIArgumentInterface param paths; keep it on that
+     * path rather than diverting it here. */
+    GType gtype = g_registered_type_info_get_g_type (info);
+    if (g_type_is_a (gtype, G_TYPE_PARAM))
+        return false;
+
+    return true;
+}
+
+/*
+ * The ref/unref functions are declared on the root fundamental type (e.g.
+ * GskRenderNode) and are not repeated on derived infos (GskColorNode), so walk
+ * up the parent chain until we find them.
+ */
+static void GetRefFunctions (GIObjectInfo *info,
+                             GIObjectInfoRefFunction *refOut,
+                             GIObjectInfoUnrefFunction *unrefOut) {
+    *refOut = NULL;
+    *unrefOut = NULL;
+
+    GIObjectInfo *current = g_base_info_ref (info);
+    while (current != NULL) {
+        auto ref = g_object_info_get_ref_function_pointer (current);
+        auto unref = g_object_info_get_unref_function_pointer (current);
+        if (ref != NULL || unref != NULL) {
+            *refOut = ref;
+            *unrefOut = unref;
+            break;
+        }
+        GIObjectInfo *parent = g_object_info_get_parent (current);
+        g_base_info_unref (current);
+        current = parent;
+    }
+
+    if (current != NULL)
+        g_base_info_unref (current);
+}
+
+void RefFundamentalForTransferFullIn (GITypeInfo *type_info, GIArgument *arg) {
+    if (arg->v_pointer == NULL)
+        return;
+
+    if (g_type_info_get_tag (type_info) != GI_TYPE_TAG_INTERFACE)
+        return;
+
+    GIBaseInfo *iface = g_type_info_get_interface (type_info);
+
+    /* The callee takes ownership of one reference (transfer-full). The JS
+     * wrapper keeps its own single reference and drops it on GC, so without an
+     * extra reference here the object would be finalized out from under the
+     * callee. This is the fundamental counterpart of RefObjectForTransferFullIn
+     * (GObjects, #439) and CopyBoxedForTransferFullIn (boxed, #409). */
+    if (IsFundamentalObjectInfo (iface)) {
+        GIObjectInfoRefFunction ref;
+        GIObjectInfoUnrefFunction unref;
+        GetRefFunctions (iface, &ref, &unref);
+        if (ref != NULL)
+            ref (arg->v_pointer);
+    }
+
+    g_base_info_unref (iface);
+}
+
+static void FundamentalDestroyed (const Nan::WeakCallbackInfo<FundamentalInstance> &info) {
+    FundamentalInstance *self = info.GetParameter ();
+
+    if (self->data != NULL && self->unref != NULL)
+        self->unref (self->data);
+
+    self->persistent->Reset ();
+    delete self->persistent;
+    delete self;
+}
+
+static void FundamentalConstructor (const Nan::FunctionCallbackInfo<Value> &info) {
+    if (!info.IsConstructCall ()) {
+        Nan::ThrowTypeError ("Not a construct call");
+        return;
+    }
+
+    Local<Object> self = info.This ();
+    GIObjectInfo *gi_info = (GIObjectInfo *) External::Cast (*info.Data ())->Value ();
+    GType gtype = g_registered_type_info_get_g_type (gi_info);
+
+    if (!info[0]->IsExternal ()) {
+        /* Fundamental types can't be created with g_object_new; they are
+         * obtained from function returns or their static constructors
+         * (e.g. `Gsk.ColorNode.new(...)`). */
+        char *message = g_strdup_printf (
+            "Cannot construct fundamental type %s directly; use its static constructor (e.g. .new())",
+            g_type_name (gtype));
+        Nan::ThrowError (message);
+        g_free (message);
+        return;
+    }
+
+    void *ptr = External::Cast (*info[0])->Value ();
+    auto ownership = (ResourceOwnership) Nan::To<int32_t> (info[1]).ToChecked ();
+
+    GIObjectInfoRefFunction ref;
+    GIObjectInfoUnrefFunction unref;
+    GetRefFunctions (gi_info, &ref, &unref);
+
+    /* Own exactly one reference for the lifetime of the wrapper. A
+     * transfer-full return (kTransfer) already handed us one; otherwise add our
+     * own so the instance stays alive while JS holds the wrapper. */
+    if (ownership != kTransfer && ref != NULL)
+        ptr = ref (ptr);
+
+    FundamentalInstance *instance = new FundamentalInstance ();
+    instance->data = ptr;
+    instance->unref = unref;
+    instance->persistent = new Persistent<Object> (self);
+    instance->persistent->SetWeak (instance, FundamentalDestroyed, WeakCallbackType::kParameter);
+
+    self->SetAlignedPointerInInternalField (0, ptr);
+    SET_OBJECT_GTYPE (self, gtype);
+}
+
+static void FundamentalToString (const Nan::FunctionCallbackInfo<Value> &info) {
+    Local<Object> self = info.This ();
+
+    if (!ValueHasInternalField (self)) {
+        Nan::ThrowTypeError ("Object is not a fundamental type");
+        return;
+    }
+
+    GType gtype = GET_OBJECT_GTYPE (self);
+    void *address = self->GetAlignedPointerFromInternalField (0);
+    char *str = g_strdup_printf ("[%s %#zx]", g_type_name (gtype), (size_t) address);
+    info.GetReturnValue ().Set (UTF8 (str));
+    g_free (str);
+}
+
+static Local<FunctionTemplate> GetFundamentalBaseTemplate () {
+    static Persistent<FunctionTemplate> baseTemplate;
+
+    if (baseTemplate.IsEmpty ()) {
+        auto tpl = New<FunctionTemplate> ();
+        tpl->SetClassName (UTF8 ("FundamentalBaseClass"));
+        Nan::SetPrototypeMethod (tpl, "toString", FundamentalToString);
+        baseTemplate.Reset (tpl);
+    }
+
+    return New (baseTemplate);
+}
+
+static void FundamentalClassDestroyed (const Nan::WeakCallbackInfo<GIBaseInfo> &info) {
+    GIBaseInfo *gi_info = info.GetParameter ();
+    GType gtype = g_registered_type_info_get_g_type (gi_info);
+
+    auto *persistentTpl = (Persistent<FunctionTemplate> *) g_type_get_qdata (gtype, GNodeJS::template_quark ());
+    auto *persistentFn  = (Persistent<Function> *)         g_type_get_qdata (gtype, GNodeJS::function_quark ());
+    delete persistentTpl;
+    delete persistentFn;
+
+    g_type_set_qdata (gtype, GNodeJS::template_quark (), NULL);
+    g_type_set_qdata (gtype, GNodeJS::function_quark (), NULL);
+
+    g_base_info_unref (gi_info);
+}
+
+static Local<FunctionTemplate> GetFundamentalTemplate (GIObjectInfo *info, GType gtype) {
+    void *data = g_type_get_qdata (gtype, GNodeJS::template_quark ());
+
+    if (data) {
+        auto *persistent = (Persistent<FunctionTemplate> *) data;
+        return New<FunctionTemplate> (*persistent);
+    }
+
+    /* The External holds a borrowed pointer; the owned ref is taken by the
+     * SetWeak below and released in FundamentalClassDestroyed. `info` stays
+     * alive for the template's whole lifetime, so the borrow is safe (mirrors
+     * boxed.cc's GetBoxedTemplate). */
+    auto tpl = New<FunctionTemplate> (FundamentalConstructor, New<External> (info));
+    tpl->SetClassName (UTF8 (g_type_name (gtype)));
+    tpl->InstanceTemplate ()->SetInternalFieldCount (1);
+    Nan::SetPrototypeTemplate (
+        tpl, "__gtype__", v8::BigInt::NewFromUnsigned (Isolate::GetCurrent (), gtype));
+
+    GType parent_type = g_type_parent (gtype);
+    if (parent_type == G_TYPE_INVALID) {
+        tpl->Inherit (GetFundamentalBaseTemplate ());
+    } else {
+        GIObjectInfo *parent_info = (GIObjectInfo *) g_irepository_find_by_gtype (NULL, parent_type);
+        if (parent_info != NULL) {
+            tpl->Inherit (GetFundamentalTemplate (parent_info, parent_type));
+            g_base_info_unref (parent_info);
+        } else {
+            tpl->Inherit (GetFundamentalBaseTemplate ());
+        }
+    }
+
+    auto *persistentTpl = new Persistent<FunctionTemplate> (tpl);
+    auto *persistentFn  = new Persistent<Function> (Nan::GetFunction (tpl).ToLocalChecked ());
+    persistentTpl->SetWeak (
+        g_base_info_ref (info), FundamentalClassDestroyed, WeakCallbackType::kParameter);
+
+    g_type_set_qdata (gtype, GNodeJS::template_quark (), persistentTpl);
+    g_type_set_qdata (gtype, GNodeJS::function_quark (), persistentFn);
+
+    return tpl;
+}
+
+MaybeLocal<Function> MakeFundamentalClass (GIObjectInfo *info) {
+    GType gtype = g_registered_type_info_get_g_type (info);
+
+    if (gtype == G_TYPE_NONE || gtype == G_TYPE_INVALID)
+        return MaybeLocal<Function> ();
+
+    void *data = g_type_get_qdata (gtype, GNodeJS::function_quark ());
+    if (data == NULL) {
+        GetFundamentalTemplate (info, gtype);
+        data = g_type_get_qdata (gtype, GNodeJS::function_quark ());
+    }
+
+    auto *persistent = (Persistent<Function> *) data;
+    return New<Function> (*persistent);
+}
+
+Local<Value> WrapperFromFundamental (GIObjectInfo *info, void *ptr, ResourceOwnership ownership) {
+    if (ptr == NULL)
+        return Nan::Null ();
+
+    /* Resolve the *actual* runtime type of the instance (e.g. GskColorNode)
+     * rather than the static return type (GskRenderNode), mirroring how
+     * WrapperFromGObject uses G_OBJECT_TYPE. Introspected fundamental types are
+     * classed GTypeInstances, so G_TYPE_FROM_INSTANCE is valid here. */
+    GIObjectInfo *resolved = NULL;
+    GType instance_gtype = G_TYPE_FROM_INSTANCE (ptr);
+    if (instance_gtype != G_TYPE_INVALID) {
+        GIBaseInfo *found = g_irepository_find_by_gtype (NULL, instance_gtype);
+        if (found != NULL) {
+            if (IsFundamentalObjectInfo (found))
+                resolved = found;
+            else
+                g_base_info_unref (found);
+        }
+    }
+
+    auto maybeConstructor = MakeFundamentalClass (resolved != NULL ? resolved : info);
+
+    if (resolved != NULL)
+        g_base_info_unref (resolved);
+
+    if (maybeConstructor.IsEmpty ())
+        return Nan::Null ();
+
+    Local<Value> args[] = {
+        New<External> (ptr),
+        New<v8::Int32> ((int32_t) ownership),
+    };
+
+    auto instance = Nan::NewInstance (maybeConstructor.ToLocalChecked (), 2, args);
+    if (instance.IsEmpty ())
+        return Nan::Null ();
+
+    return instance.ToLocalChecked ();
+}
+
+};

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -36,51 +36,20 @@ struct FundamentalInstance {
 };
 
 bool IsFundamentalObjectInfo (GIObjectInfo *info) {
-    GIInfoType info_type = g_base_info_get_type (info);
-    if (info_type != GI_INFO_TYPE_OBJECT) {
-        if (g_getenv ("NODE_GTK_FUND_DEBUG"))
-            g_printerr ("[fund-dbg] %s.%s: info_type=%d (not OBJECT) -> false\n",
-                    g_base_info_get_namespace (info), g_base_info_get_name (info), info_type);
+    if (g_base_info_get_type (info) != GI_INFO_TYPE_OBJECT)
         return false;
-    }
-
-    GType gtype = g_registered_type_info_get_g_type (info);
-    bool flagged = g_object_info_get_fundamental (info);
-
-    if (g_getenv ("NODE_GTK_FUND_DEBUG"))
-        g_printerr ("[fund-dbg] %s.%s: gtype=%lu name=%s fundamental_flag=%d "
-                    "IS_OBJECT=%d IS_PARAM=%d\n",
-                g_base_info_get_namespace (info), g_base_info_get_name (info),
-                (unsigned long) gtype,
-                gtype != G_TYPE_INVALID ? g_type_name (gtype) : "(invalid)",
-                flagged,
-                gtype != G_TYPE_INVALID ? G_TYPE_IS_OBJECT (gtype) : -1,
-                gtype != G_TYPE_INVALID ? g_type_is_a (gtype, G_TYPE_PARAM) : -1);
+    if (!g_object_info_get_fundamental (info))
+        return false;
 
     /* GParamSpec is also a fundamental (non-GObject) type, but it has its own
      * dedicated wrapper (param_spec.cc) that predates this one and is used by
      * the value.cc / V8ToGIArgumentInterface param paths; keep it on that
      * path rather than diverting it here. */
-    if (gtype != G_TYPE_INVALID && g_type_is_a (gtype, G_TYPE_PARAM))
+    GType gtype = g_registered_type_info_get_g_type (info);
+    if (g_type_is_a (gtype, G_TYPE_PARAM))
         return false;
 
-    /* Primary signal: the typelib's glib:fundamental flag. */
-    if (flagged)
-        return true;
-
-    /* Fallback: a GIObjectInfo whose GType exists but is NOT a GObject
-     * descendant can only be a fundamental type (e.g. GskRenderNode, which
-     * registers its own GType hierarchy via g_type_register_fundamental).
-     * Some platforms' typelibs don't carry the glib:fundamental attribute
-     * reliably — the Windows/MSYS2 GTK4 build reports it FALSE for
-     * GskRenderNode, so it fell back to the GObject wrapper and fired an
-     * `invalid cast ... to GObject` critical (#468). Trust the GType hierarchy
-     * as well; on GObject subclasses G_TYPE_IS_OBJECT is true, so they keep the
-     * GObject path. */
-    if (gtype != G_TYPE_INVALID && gtype != G_TYPE_NONE && !G_TYPE_IS_OBJECT (gtype))
-        return true;
-
-    return false;
+    return true;
 }
 
 /*

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -112,7 +112,10 @@ static void FundamentalDestroyed (const Nan::WeakCallbackInfo<FundamentalInstanc
     if (self->data != NULL && self->unref != NULL)
         self->unref (self->data);
 
-    self->persistent->Reset ();
+    /* Nan's kParameter weak callback already Reset()s the handle in its first
+     * pass (nan_weak.h); calling Reset() again here would double-destroy the
+     * global handle (V8 "IsInUse" fatal). Just free our bookkeeping, matching
+     * BoxedDestroyed. */
     delete self->persistent;
     delete self;
 }
@@ -301,6 +304,148 @@ Local<Value> WrapperFromFundamental (GIObjectInfo *info, void *ptr, ResourceOwne
         return Nan::Null ();
 
     return instance.ToLocalChecked ();
+}
+
+
+/*
+ * GVariant
+ *
+ * GVariant is a fundamental ref-counted type, but GI classes it as a
+ * GIStructInfo (g_type == G_TYPE_VARIANT), so the object-info machinery above
+ * (G_TYPE_FROM_INSTANCE, introspected ref/unref functions) does not apply. It
+ * uses the shared FundamentalInstance lifetime with hardcoded g_variant_ref/
+ * unref and floating-reference handling (g_variant_ref_sink / take_ref).
+ */
+
+/* Matches GIObjectInfoUnrefFunction's signature so FundamentalInstance can call
+ * it uniformly; avoids a function-pointer cast. */
+static void VariantUnref (void *data) {
+    g_variant_unref ((GVariant *) data);
+}
+
+bool IsVariantInfo (GIBaseInfo *info) {
+    GIInfoType type = g_base_info_get_type (info);
+    if (type != GI_INFO_TYPE_STRUCT
+            && type != GI_INFO_TYPE_BOXED
+            && type != GI_INFO_TYPE_UNION
+            && type != GI_INFO_TYPE_OBJECT)
+        return false;
+    return g_registered_type_info_get_g_type (info) == G_TYPE_VARIANT;
+}
+
+bool IsVariantTypeInfo (GITypeInfo *type_info) {
+    if (g_type_info_get_tag (type_info) != GI_TYPE_TAG_INTERFACE)
+        return false;
+    GIBaseInfo *iface = g_type_info_get_interface (type_info);
+    bool result = IsVariantInfo (iface);
+    g_base_info_unref (iface);
+    return result;
+}
+
+static void VariantConstructor (const Nan::FunctionCallbackInfo<Value> &info) {
+    if (!info.IsConstructCall ()) {
+        Nan::ThrowTypeError ("Not a construct call");
+        return;
+    }
+
+    Local<Object> self = info.This ();
+
+    if (!info[0]->IsExternal ()) {
+        /* Like the object fundamentals, variants are obtained from function
+         * returns or their static constructors (e.g. GLib.Variant.newString),
+         * not built with `new`. */
+        Nan::ThrowError (
+            "Cannot construct GLib.Variant directly; use a static constructor (e.g. GLib.Variant.newString())");
+        return;
+    }
+
+    void *ptr = External::Cast (*info[0])->Value ();
+    auto ownership = (ResourceOwnership) Nan::To<int32_t> (info[1]).ToChecked ();
+
+    /* Own exactly one full (non-floating) reference for the wrapper's lifetime.
+     * A transfer-full return already handed us a reference to adopt (take_ref
+     * sinks it if it was floating); otherwise add our own (ref_sink sinks a
+     * fresh floating variant, or refs a shared one). */
+    if (ownership == kTransfer)
+        ptr = g_variant_take_ref ((GVariant *) ptr);
+    else
+        ptr = g_variant_ref_sink ((GVariant *) ptr);
+
+    FundamentalInstance *instance = new FundamentalInstance ();
+    instance->data = ptr;
+    instance->unref = VariantUnref;
+    instance->persistent = new Persistent<Object> (self);
+    instance->persistent->SetWeak (instance, FundamentalDestroyed, WeakCallbackType::kParameter);
+
+    self->SetAlignedPointerInInternalField (0, ptr);
+    SET_OBJECT_GTYPE (self, G_TYPE_VARIANT);
+}
+
+static Local<FunctionTemplate> GetVariantTemplate () {
+    GType gtype = G_TYPE_VARIANT;
+    void *data = g_type_get_qdata (gtype, GNodeJS::template_quark ());
+
+    if (data) {
+        auto *persistent = (Persistent<FunctionTemplate> *) data;
+        return New<FunctionTemplate> (*persistent);
+    }
+
+    auto tpl = New<FunctionTemplate> (VariantConstructor);
+    tpl->SetClassName (UTF8 (g_type_name (gtype)));
+    tpl->InstanceTemplate ()->SetInternalFieldCount (1);
+    Nan::SetPrototypeTemplate (
+        tpl, "__gtype__", v8::BigInt::NewFromUnsigned (Isolate::GetCurrent (), gtype));
+    tpl->Inherit (GetFundamentalBaseTemplate ());
+
+    /* G_TYPE_VARIANT is a static built-in fundamental that never unloads, so
+     * (unlike the per-namespace fundamental object templates) there is no
+     * class-destroyed weak callback to tear the cache down. */
+    auto *persistentTpl = new Persistent<FunctionTemplate> (tpl);
+    auto *persistentFn  = new Persistent<Function> (Nan::GetFunction (tpl).ToLocalChecked ());
+    g_type_set_qdata (gtype, GNodeJS::template_quark (), persistentTpl);
+    g_type_set_qdata (gtype, GNodeJS::function_quark (), persistentFn);
+
+    return tpl;
+}
+
+Local<Function> MakeVariantClass (GIBaseInfo *info) {
+    void *data = g_type_get_qdata (G_TYPE_VARIANT, GNodeJS::function_quark ());
+    if (data == NULL) {
+        GetVariantTemplate ();
+        data = g_type_get_qdata (G_TYPE_VARIANT, GNodeJS::function_quark ());
+    }
+
+    auto *persistent = (Persistent<Function> *) data;
+    return New<Function> (*persistent);
+}
+
+Local<Value> WrapperFromVariant (void *ptr, ResourceOwnership ownership) {
+    if (ptr == NULL)
+        return Nan::Null ();
+
+    Local<Function> constructor = MakeVariantClass (NULL);
+
+    Local<Value> args[] = {
+        New<External> (ptr),
+        New<v8::Int32> ((int32_t) ownership),
+    };
+
+    auto instance = Nan::NewInstance (constructor, 2, args);
+    if (instance.IsEmpty ())
+        return Nan::Null ();
+
+    return instance.ToLocalChecked ();
+}
+
+void RefVariantForTransferFullIn (GITypeInfo *type_info, GIArgument *arg) {
+    if (arg->v_pointer == NULL)
+        return;
+
+    /* The callee takes ownership of one reference; keep our own so the JS
+     * wrapper isn't unref'd out from under it (counterpart of the boxed/object
+     * transfer-full helpers). */
+    if (IsVariantTypeInfo (type_info))
+        arg->v_pointer = g_variant_ref ((GVariant *) arg->v_pointer);
 }
 
 };

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -38,18 +38,33 @@ struct FundamentalInstance {
 bool IsFundamentalObjectInfo (GIObjectInfo *info) {
     if (g_base_info_get_type (info) != GI_INFO_TYPE_OBJECT)
         return false;
-    if (!g_object_info_get_fundamental (info))
-        return false;
+
+    GType gtype = g_registered_type_info_get_g_type (info);
 
     /* GParamSpec is also a fundamental (non-GObject) type, but it has its own
      * dedicated wrapper (param_spec.cc) that predates this one and is used by
      * the value.cc / V8ToGIArgumentInterface param paths; keep it on that
      * path rather than diverting it here. */
-    GType gtype = g_registered_type_info_get_g_type (info);
-    if (g_type_is_a (gtype, G_TYPE_PARAM))
+    if (gtype != G_TYPE_INVALID && g_type_is_a (gtype, G_TYPE_PARAM))
         return false;
 
-    return true;
+    /* Primary signal: the typelib's glib:fundamental flag. */
+    if (g_object_info_get_fundamental (info))
+        return true;
+
+    /* Fallback: a GIObjectInfo whose GType exists but is NOT a GObject
+     * descendant can only be a fundamental type (e.g. GskRenderNode, which
+     * registers its own GType hierarchy via g_type_register_fundamental).
+     * Some platforms' typelibs don't carry the glib:fundamental attribute
+     * reliably — the Windows/MSYS2 GTK4 build reports it FALSE for
+     * GskRenderNode, so it fell back to the GObject wrapper and fired an
+     * `invalid cast ... to GObject` critical (#468). Trust the GType hierarchy
+     * as well; on GObject subclasses G_TYPE_IS_OBJECT is true, so they keep the
+     * GObject path. */
+    if (gtype != G_TYPE_INVALID && gtype != G_TYPE_NONE && !G_TYPE_IS_OBJECT (gtype))
+        return true;
+
+    return false;
 }
 
 /*

--- a/src/fundamental.cc
+++ b/src/fundamental.cc
@@ -36,10 +36,26 @@ struct FundamentalInstance {
 };
 
 bool IsFundamentalObjectInfo (GIObjectInfo *info) {
-    if (g_base_info_get_type (info) != GI_INFO_TYPE_OBJECT)
+    GIInfoType info_type = g_base_info_get_type (info);
+    if (info_type != GI_INFO_TYPE_OBJECT) {
+        if (g_getenv ("NODE_GTK_FUND_DEBUG"))
+            g_printerr ("[fund-dbg] %s.%s: info_type=%d (not OBJECT) -> false\n",
+                    g_base_info_get_namespace (info), g_base_info_get_name (info), info_type);
         return false;
+    }
 
     GType gtype = g_registered_type_info_get_g_type (info);
+    bool flagged = g_object_info_get_fundamental (info);
+
+    if (g_getenv ("NODE_GTK_FUND_DEBUG"))
+        g_printerr ("[fund-dbg] %s.%s: gtype=%lu name=%s fundamental_flag=%d "
+                    "IS_OBJECT=%d IS_PARAM=%d\n",
+                g_base_info_get_namespace (info), g_base_info_get_name (info),
+                (unsigned long) gtype,
+                gtype != G_TYPE_INVALID ? g_type_name (gtype) : "(invalid)",
+                flagged,
+                gtype != G_TYPE_INVALID ? G_TYPE_IS_OBJECT (gtype) : -1,
+                gtype != G_TYPE_INVALID ? g_type_is_a (gtype, G_TYPE_PARAM) : -1);
 
     /* GParamSpec is also a fundamental (non-GObject) type, but it has its own
      * dedicated wrapper (param_spec.cc) that predates this one and is used by
@@ -49,7 +65,7 @@ bool IsFundamentalObjectInfo (GIObjectInfo *info) {
         return false;
 
     /* Primary signal: the typelib's glib:fundamental flag. */
-    if (g_object_info_get_fundamental (info))
+    if (flagged)
         return true;
 
     /* Fallback: a GIObjectInfo whose GType exists but is NOT a GObject

--- a/src/fundamental.h
+++ b/src/fundamental.h
@@ -41,4 +41,31 @@ Local<Value> WrapperFromFundamental (GIObjectInfo *info, void *ptr, ResourceOwne
  * Fundamental counterpart of RefObjectForTransferFullIn / CopyBoxedForTransferFullIn. */
 void RefFundamentalForTransferFullIn (GITypeInfo *type_info, GIArgument *arg);
 
+
+/*
+ * GVariant is also a fundamental (non-GObject) ref-counted type, but GObject-
+ * Introspection reports it as a GI_INFO_TYPE_STRUCT (a GIStructInfo) with
+ * g_type == G_TYPE_VARIANT, not as a fundamental GIObjectInfo. It is refcounted
+ * with g_variant_ref/unref (and has floating references), so it gets the same
+ * single-owned-reference wrapper as the object fundamentals above rather than
+ * the boxed copy/free path. Its JS class is still built from the struct info
+ * (so its introspected methods attach), just with this ref/unref lifetime.
+ */
+
+/* True when `info` is a registered type whose g_type is G_TYPE_VARIANT. */
+bool IsVariantInfo (GIBaseInfo *info);
+
+/* True when `type_info` is an interface referring to G_TYPE_VARIANT. */
+bool IsVariantTypeInfo (GITypeInfo *type_info);
+
+/* Build (or fetch the cached) constructor for GLib.Variant. */
+Local<Function> MakeVariantClass (GIBaseInfo *info);
+
+/* Wrap a GVariant for return to JS, taking a reference according to `ownership`
+ * (kTransfer: adopt the incoming reference; otherwise add our own). */
+Local<Value> WrapperFromVariant (void *ptr, ResourceOwnership ownership);
+
+/* Transfer-full IN counterpart for GVariant (adds the callee's reference). */
+void RefVariantForTransferFullIn (GITypeInfo *type_info, GIArgument *arg);
+
 };

--- a/src/fundamental.h
+++ b/src/fundamental.h
@@ -1,0 +1,44 @@
+/*
+ * fundamental.h
+ *
+ * Wrapping of GLib *fundamental* ref-counted types that are not GObjects —
+ * e.g. GskRenderNode, which has its own gsk_render_node_ref()/unref() instead
+ * of the GObject machinery. GObject-Introspection reports these as
+ * GI_INFO_TYPE_OBJECT (a GIObjectInfo) with g_object_info_get_fundamental()
+ * == TRUE, but running the GObject wrapper path over them fires G_IS_OBJECT
+ * assertions (#468). They get their own thin wrapper here.
+ */
+
+#pragma once
+
+#include <node.h>
+#include <nan.h>
+#include <girepository.h>
+#include <glib-object.h>
+
+#include "value.h"
+
+using v8::Function;
+using v8::Local;
+using v8::MaybeLocal;
+using v8::Value;
+
+namespace GNodeJS {
+
+/* True when the GIObjectInfo describes a fundamental (non-GObject) type. */
+bool IsFundamentalObjectInfo (GIObjectInfo *info);
+
+/* Build (or fetch the cached) constructor for a fundamental type. Mirrors
+ * MakeClass()/MakeBoxedClass(); JS attaches the introspected methods to it. */
+MaybeLocal<Function> MakeFundamentalClass (GIObjectInfo *info);
+
+/* Wrap a fundamental instance for return to JS, taking a reference according
+ * to `ownership` (kTransfer: adopt the incoming ref; otherwise add our own). */
+Local<Value> WrapperFromFundamental (GIObjectInfo *info, void *ptr, ResourceOwnership ownership);
+
+/* Add the reference a transfer-full IN argument's callee will own, so the
+ * instance isn't finalized out from under it when the JS wrapper is GC'd.
+ * Fundamental counterpart of RefObjectForTransferFullIn / CopyBoxedForTransferFullIn. */
+void RefFundamentalForTransferFullIn (GITypeInfo *type_info, GIArgument *arg);
+
+};

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -5,6 +5,7 @@
 #include "async_call_environment.h"
 #include "boxed.h"
 #include "debug.h"
+#include "fundamental.h"
 #include "function.h"
 #include "gi.h"
 #include "gobject.h"
@@ -170,7 +171,11 @@ NAN_METHOD(MakeFunction) {
 
 NAN_METHOD(MakeObjectClass) {
     BaseInfo gi_info(info[0]);
-    auto klass = GNodeJS::MakeClass(*gi_info);
+    // Fundamental (non-GObject) types such as GskRenderNode need their own
+    // ref/unref-based wrapper rather than the GObject machinery (#468).
+    auto klass = GNodeJS::IsFundamentalObjectInfo(*gi_info)
+        ? GNodeJS::MakeFundamentalClass(*gi_info)
+        : GNodeJS::MakeClass(*gi_info);
     if (!klass.IsEmpty())
         info.GetReturnValue().Set(klass.ToLocalChecked());
 }

--- a/src/value.cc
+++ b/src/value.cc
@@ -841,6 +841,15 @@ bool V8ToGIArgumentInterface(GIBaseInfo *gi_info, GIArgument *arg, Local<Value> 
             arg->v_pointer = ParamSpec::FromWrapper(value);
             break;
         }
+
+        if (IsFundamentalObjectInfo(gi_info)) {
+            // A fundamental (non-GObject) instance such as GskRenderNode: take
+            // the raw wrapped pointer. GObjectFromWrapper would G_OBJECT()-cast
+            // it — silently on Linux (cast checks compiled out) but a fatal
+            // `invalid cast ... to GObject` under G_DEBUG on Windows (#468).
+            arg->v_pointer = PointerFromWrapper(value);
+            break;
+        }
         // fallthrough
     }
     case GI_INFO_TYPE_INTERFACE:

--- a/src/value.cc
+++ b/src/value.cc
@@ -6,6 +6,7 @@
 
 #include "error.h"
 #include "boxed.h"
+#include "fundamental.h"
 #include "function.h"
 #include "gi.h"
 #include "gobject.h"
@@ -136,7 +137,9 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
              * of a GObject, instead this represent the object type (eg class).  A GObject
              * has methods, fields, properties, signals, interfaces, constants and virtual functions. */
             case GI_INFO_TYPE_OBJECT:
-                if (G_IS_PARAM_SPEC(arg->v_pointer))
+                if (IsFundamentalObjectInfo(interface_info))
+                    value = WrapperFromFundamental(interface_info, arg->v_pointer, ownership);
+                else if (G_IS_PARAM_SPEC(arg->v_pointer))
                     value = ParamSpec::FromGParamSpec((GParamSpec *)arg->v_pointer);
                 else
                     value = WrapperFromGObject((GObject *)arg->v_pointer);

--- a/src/value.cc
+++ b/src/value.cc
@@ -147,7 +147,12 @@ Local<Value> GIArgumentToV8(GITypeInfo *type_info, GIArgument *arg, long length,
             case GI_INFO_TYPE_BOXED:
             case GI_INFO_TYPE_STRUCT:
             case GI_INFO_TYPE_UNION:
-                value = WrapperFromBoxed (interface_info, arg->v_pointer, ownership);
+                // GVariant is a struct-classed fundamental: refcount it via the
+                // fundamental wrapper rather than g_boxed_copy (#465).
+                if (IsVariantInfo (interface_info))
+                    value = WrapperFromVariant (arg->v_pointer, ownership);
+                else
+                    value = WrapperFromBoxed (interface_info, arg->v_pointer, ownership);
                 break;
             case GI_INFO_TYPE_ENUM:
                 value = New<Number>(arg->v_int);
@@ -1729,7 +1734,7 @@ bool CanConvertV8ToGValue(GValue *gvalue, Local<Value> value) {
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         return false;
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        return false;
+        return value->IsNullOrUndefined() || ValueIsInstanceOfGType(value, G_TYPE_VARIANT);
     }
 
     ERROR("Unhandled GValue type: %s (please report this)",
@@ -1822,7 +1827,13 @@ bool V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership)
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         ERROR("Unsupported type: pointer");
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        ERROR("Unsupported type: variant");
+        // GVariant is nullable. g_value_set_variant refs a non-NULL variant
+        // (and sinks a floating one), so the GValue holds its own reference
+        // independent of the JS wrapper (#465).
+        g_value_set_variant (gvalue,
+                value->IsNullOrUndefined()
+                    ? NULL
+                    : (GVariant *) PointerFromWrapper (value));
     } else {
         ERROR("Unhandled GValue type: %s (please report this)",
                 g_type_name(G_VALUE_TYPE(gvalue)));
@@ -1899,7 +1910,9 @@ Local<Value> GValueToV8(const GValue *gvalue, ResourceOwnership ownership) {
     } else if (G_VALUE_HOLDS_POINTER (gvalue)) {
         ERROR("Unsuported type: pointer");
     } else if (G_VALUE_HOLDS_VARIANT (gvalue)) {
-        ERROR("Unsuported type: variant");
+        // GVariant is a struct-classed fundamental; the fundamental wrapper
+        // takes its own reference according to `ownership` (#465).
+        return WrapperFromVariant (g_value_get_variant (gvalue), ownership);
     } else {
         // Don't abort the whole process on a GValue type we can't convert
         // (e.g. GStreamer's GstValueArray / GstValueList, #389). Warn and

--- a/tests/fundamental__gsk_render_node.js
+++ b/tests/fundamental__gsk_render_node.js
@@ -1,0 +1,89 @@
+/*
+ * fundamental__gsk_render_node.js
+ *
+ * Regression test for #468: Gtk.Snapshot.toNode() returns a GskRenderNode,
+ * which is a fundamental ref-counted type (gsk_render_node_ref/unref), NOT a
+ * GObject. node-gtk used to run its GObject wrapper path over it, firing 8
+ * `G_IS_OBJECT` GLib-GObject criticals per call. It must now wrap it as its
+ * own fundamental type with no criticals.
+ */
+
+const gi = require('../lib/')
+const { describe, it, expect, assert, isntUndefined, skip } = require('./__common__.js')
+const child_process = require('child_process')
+
+let Gtk, Gdk, Graphene, Gsk
+try {
+  Gtk = gi.require('Gtk', '4.0')
+  Gdk = gi.require('Gdk', '4.0')
+  Graphene = gi.require('Graphene', '1.0')
+  Gsk = gi.require('Gsk', '4.0')
+  Gtk.init()
+} catch (e) {
+  console.log('Gtk 4.0 not available, skipping:', e.message)
+  skip()
+}
+
+function makeNode() {
+  const snapshot = Gtk.Snapshot.new()
+  const color = new Gdk.RGBA()
+  color.red = 1
+  color.alpha = 1
+  const rect = new Graphene.Rect()
+  rect.init(0, 0, 10, 10)
+  snapshot.appendColor(color, rect)
+  return snapshot.toNode()
+}
+
+// Child mode: exercise the repro then force GC so the fundamental teardown
+// (unref) runs too. Under G_DEBUG=fatal-criticals any g_object_* call on the
+// non-GObject node aborts the process, so a clean exit proves the fix.
+if (process.env.NODE_GTK_468_CHILD) {
+  const node = makeNode()
+  // Touch a GskRenderNode method to prove the wrapper is usable.
+  node.getNodeType()
+  if (global.gc) {
+    global.gc()
+    global.gc()
+  }
+  process.exit(0)
+}
+
+describe('Gsk.RenderNode fundamental-type wrapping (#468)', () => {
+
+  it('wraps a GskRenderNode as its own fundamental type with working methods', () => {
+    const node = makeNode()
+    isntUndefined(node, 'toNode() returned undefined')
+    assert(node !== null, 'toNode() returned null')
+
+    // It is a GskRenderNode subclass and inherits the fundamental base.
+    expect(node.constructor.name, 'GskColorNode')
+    assert(typeof node.getNodeType === 'function',
+      'expected introspected GskRenderNode method getNodeType()')
+
+    // Calling a method (which unwraps `this` back to the native pointer) works.
+    const nodeType = node.getNodeType()
+    expect(nodeType, Gsk.RenderNodeType.COLOR_NODE)
+  })
+
+  it('produces no G_IS_OBJECT criticals on wrap, use and teardown', () => {
+    const child = child_process.spawnSync(
+      process.execPath,
+      ['--expose-gc', __filename],
+      {
+        encoding: 'utf8',
+        env: Object.assign({}, process.env, {
+          NODE_GTK_468_CHILD: '1',
+          G_DEBUG: 'fatal-criticals',
+        }),
+      }
+    )
+
+    const output = (child.stderr || '') + (child.stdout || '')
+    assert(!/CRITICAL|G_IS_OBJECT/.test(output),
+      'expected no GObject criticals, got:\n' + output)
+    assert(child.status === 0,
+      'child exited with status ' + child.status + ' signal ' + child.signal + '\n' + output)
+  })
+
+})

--- a/tests/fundamental__gsk_render_node.js
+++ b/tests/fundamental__gsk_render_node.js
@@ -75,6 +75,7 @@ describe('Gsk.RenderNode fundamental-type wrapping (#468)', () => {
         env: Object.assign({}, process.env, {
           NODE_GTK_468_CHILD: '1',
           G_DEBUG: 'fatal-criticals',
+          NODE_GTK_FUND_DEBUG: '1',
         }),
       }
     )

--- a/tests/fundamental__gsk_render_node.js
+++ b/tests/fundamental__gsk_render_node.js
@@ -75,7 +75,6 @@ describe('Gsk.RenderNode fundamental-type wrapping (#468)', () => {
         env: Object.assign({}, process.env, {
           NODE_GTK_468_CHILD: '1',
           G_DEBUG: 'fatal-criticals',
-          NODE_GTK_FUND_DEBUG: '1',
         }),
       }
     )

--- a/tests/signal__variant.js
+++ b/tests/signal__variant.js
@@ -1,0 +1,111 @@
+/*
+ * signal__variant.js
+ *
+ * A GVariant marshalled INTO a signal handler (e.g. the parameter of
+ * Gio.SimpleAction::activate / ::change-state) must arrive as a valid,
+ * readable variant, not a wrapper pointing at NULL (#465). GVariant is a
+ * refcounted fundamental type (G_TYPE_VARIANT), not a boxed type, so it is
+ * wrapped by the fundamental (g_variant_ref/unref) path rather than the boxed
+ * copy/free one — while still exposing its introspected struct methods.
+ */
+
+const gi = require('../lib/')
+const GLib = gi.require('GLib', '2.0')
+const Gio = gi.require('Gio', '2.0')
+const { describe, it, assert, expect } = require('./__common__.js')
+
+const gc = global.gc || (() => {})
+
+describe('GVariant wrapper', () => {
+
+  it('is a GLib.Variant with working methods', () => {
+    const v = GLib.Variant.newString('hi')
+    assert(v instanceof GLib.Variant, 'instanceof GLib.Variant')
+    expect(v.constructor.name, 'GVariant')
+    expect(v.getString()[0], 'hi')
+    expect(GLib.Variant.newBoolean(true).getBoolean(), true)
+    expect(GLib.Variant.newInt32(42).getInt32(), 42)
+  })
+
+  it('cannot be constructed with new (use a static constructor)', () => {
+    let threw = false
+    try { new GLib.Variant('s', 'x') } catch (e) { threw = true }
+    assert(threw, 'new GLib.Variant should throw')
+  })
+})
+
+describe('GVariant passed into a signal handler', () => {
+
+  it('is readable inside the handler (the #465 repro)', () => {
+    const action = Gio.SimpleAction.new('t', GLib.VariantType.new('s'))
+    let seen = null
+    action.on('activate', (parameter) => {
+      seen = parameter.getString()[0]
+    })
+
+    const v = GLib.Variant.newString('hello-world')
+    expect(v.getString()[0], 'hello-world')  // JS-side read
+    action.activate(v)
+    expect(seen, 'hello-world')              // read inside the handler
+  })
+
+  it('gives the handler its own reference that outlives the emission', () => {
+    const action = Gio.SimpleAction.new('u', GLib.VariantType.new('s'))
+    let captured = null
+    action.on('activate', (parameter) => { captured = parameter })
+
+    action.activate(GLib.Variant.newString('kept-alive'))
+    gc()
+
+    assert(captured instanceof GLib.Variant, 'captured is a GLib.Variant')
+    expect(captured.getString()[0], 'kept-alive')
+  })
+
+  it('carries the requested value into ::change-state', () => {
+    const action = Gio.SimpleAction.newStateful(
+      's', GLib.VariantType.new('s'), GLib.Variant.newString('a'))
+    let requested = null
+    action.on('change-state', (value) => {
+      requested = value.getString()[0]
+      action.setState(value)  // exercises writing a variant back out (V8ToGValue)
+    })
+
+    action.changeState(GLib.Variant.newString('b'))
+    expect(requested, 'b')
+    expect(action.getState().getString()[0], 'b')
+  })
+
+  it('does not leak or double-free across many round-trips + GC', () => {
+    const action = Gio.SimpleAction.new('r', GLib.VariantType.new('s'))
+    let seen = null
+    action.on('activate', (parameter) => { seen = parameter.getString()[0] })
+
+    for (let i = 0; i < 3000; i++) {
+      action.activate(GLib.Variant.newString('value-' + i))
+      expect(seen, 'value-' + i)
+      if (i % 100 === 0)
+        gc()
+    }
+    gc()
+  })
+})
+
+describe('GVariant as a GObject property', () => {
+
+  it('reads back through the GValue path (GValueToV8)', () => {
+    const action = Gio.SimpleAction.newStateful(
+      'g', GLib.VariantType.new('s'), GLib.Variant.newString('hello'))
+    assert(action.state instanceof GLib.Variant, 'state is a GLib.Variant')
+    expect(action.state.getString()[0], 'hello')
+  })
+
+  it('sets at construction through the GValue path (V8ToGValue)', () => {
+    const action = new Gio.SimpleAction({
+      name: 'c',
+      state: GLib.Variant.newString('constructed'),
+    })
+    expect(action.state.getString()[0], 'constructed')
+    gc()
+    expect(action.state.getString()[0], 'constructed')
+  })
+})


### PR DESCRIPTION
Fixes #468.

## Problem

`Gtk.Snapshot.to_node()` returns a `GskRenderNode`, which is a GLib **fundamental** ref-counted type (`gsk_render_node_ref()` / `gsk_render_node_unref()`) — it is **not** a `GObject`. GObject-Introspection reports it as `GI_INFO_TYPE_OBJECT` with `g_object_info_get_fundamental() == TRUE`, but node-gtk ran its GObject wrapper path over it (`g_object_ref_sink` + `g_object_add_toggle_ref` + `get`/`set_qdata` + `g_object_weak_ref` + `g_object_class_find_property`). Every one of those fails its `G_IS_OBJECT` assertion — **8 GLib-GObject criticals per call** — and the object's lifecycle was handled incorrectly (a toggle-ref/weak-ref taken on a non-GObject). Since this fires on every GSK snapshot, any app rendering a widget to a texture offscreen got a steady stream of criticals per frame.

## Fix

Add a dedicated fundamental-type wrapper (`src/fundamental.{cc,h}`) modelled on the existing boxed wrapper, that:

- **owns exactly one reference** — taken via the type's introspected ref function for a transfer-none value, or adopted from a transfer-full return — and drops it on GC via the unref function. No toggle-ref / qdata / weak-ref machinery.
- **builds per-GType classes** so the JS side (`makeObject`) attaches the introspected methods exactly as before, and resolves the **actual runtime type** with `G_TYPE_FROM_INSTANCE` (e.g. `GskColorNode`) rather than the static return type (`GskRenderNode`), mirroring how `WrapperFromGObject` uses `G_OBJECT_TYPE`.
- **refs transfer-full IN arguments** so a callee-owned reference is accounted for — the fundamental counterpart of the GObject (#439) and boxed (#409) transfer-full-IN fixes.

`GParamSpec` is *also* a fundamental type, but it has its own dedicated wrapper (`param_spec.cc`); `IsFundamentalObjectInfo()` excludes `G_TYPE_PARAM` so param specs stay on that path (both for value marshalling and class creation).

Routing changes: `GIArgumentToV8` (`src/value.cc`) and `MakeObjectClass` (`src/gi.cc`) send fundamentals to the new wrapper.

## Verification

Before (master): the repro prints the 8 `G_IS_OBJECT` criticals. After: **0 criticals**, `node.constructor.name === 'GskColorNode'`, methods work, and pass-back/round-trip (`Gsk.ContainerNode.new([a, b])`, `getChild`, `getBounds`, `serialize`) all run cleanly under `G_DEBUG=fatal-criticals` including GC teardown.

Adds `tests/fundamental__gsk_render_node.js`, which asserts the node wraps as its own type with working methods and — in a child process under `G_DEBUG=fatal-criticals` — that no `G_IS_OBJECT` criticals fire on wrap, use, or GC teardown. Full existing suite still passes (the one unrelated `require.js` failure is a pre-existing local-typelib version conflict, present on `master` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)