### PR TITLE
v4.0.0: Node 26 support, drop Node 20, fundamental types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Changes to be released are kept in the unreleased section.
 
 ## Unreleased
 
+## v4.0.0
+
+### Breaking changes
+
+- **Dropped support for Node.js 20.** Prebuilt binaries are now published for
+  Node.js **22**, **24** and **26**.
+
+### Features
+
+- **Node.js 26 support** (V8 14 / ABI 147). The native binding was ported to the
+  V8 APIs shipped in Node 26, preferring Nan wrappers over raw V8 version guards.
+
 ### Fixes
 
 - Methods from a `GInterface` are now available directly on instances of
@@ -13,6 +25,30 @@ Changes to be released are kept in the unreleased section.
   `Gio.File.prototype`. The interface methods are now mixed into the instance's
   prototype at wrap time, so they can be called directly. This also removes the
   need for the manual `getFile()` prototype fixups in the Gtk 4 overrides (#441).
+- **Fundamental (non-`GObject`) reference-counted types are now wrapped
+  correctly.** Types such as `Gsk.RenderNode` were previously wrapped as though
+  they were `GObject`s, which produced `G_IS_OBJECT` criticals on wrap, use and
+  teardown. They are now handled by a dedicated fundamental-type subsystem that
+  ref/unrefs them through their own type's vtable rather than toggle-referencing
+  them (#468).
+- **`GLib.Variant` passed into a signal handler is no longer NULL or corrupt.**
+  `GVariant` is now wrapped as a ref-counted fundamental type, so a variant handed
+  to a signal callback (e.g. `Gio.SimpleAction`'s `::change-state`) is readable
+  inside the handler and keeps its own reference for the lifetime of the wrapper
+  (#465).
+- Nullable `char *` / array return values now return `null` instead of `""` / `[]`
+  at end-of-stream (for example `Gio.DataInputStream.readLineFinish()` at EOF)
+  (#467).
+
+### Internal
+
+- Dropped the `deasync` dependency — the last native `devDependency`. Async
+  `describe()` blocks in the test suite now let each test process's own event loop
+  drain the promise instead of blocking on `deasync`, whose pinned
+  `node-addon-api` no longer builds on Node 26.
+- The MSVC (Windows) build strips Node 26's ClangCL/ThinLTO linker flags, which
+  are emitted for the MinGW toolchain but break the MSVC toolchain node-gtk uses
+  on Windows.
 
 ## v3.0.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 `node-gtk` lets you build native GTK apps on **linux**, **macOS** and  **windows**
 with full **ESM**, **TypeScript** and **CSS hot-reload** support. Prebuilt binaries 
-are available for Node.js versions **20**, **22** and **24**.
+are available for Node.js versions **22**, **24** and **26**.
 
 <p align="center">
   <img src="./img/browser.png" style="max-width: 500px; height: auto;" alt="A web browser build with node-gtk" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-gtk",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-gtk",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-gtk",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "GNOME Gtk+ bindings for NodeJS",
   "main": "lib/index.js",
   "exports": {


### PR DESCRIPTION
Cuts the **v4.0.0** release. All of the code is already on `master`; this PR is
the release bump (version, changelog, README) and exists to confirm the whole
matrix still builds green before tagging/publishing.

### What v4.0.0 bundles (already merged to master)

- **Node.js 26 support** (V8 14 / ABI 147), ported preferring Nan wrappers over
  raw V8 version guards (#474).
- **Dropped Node.js 20.** Prebuilts now cover Node **22 / 24 / 26**; CI matrix
  updated to match.
- **Fundamental (non-`GObject`) type wrapping** — `Gsk.RenderNode` et al. are
  ref/unref'd through their own type vtable instead of being mis-wrapped as
  `GObject`s (no more `G_IS_OBJECT` criticals) (#468).
- **`GLib.Variant` into signal handlers** is no longer NULL/corrupt — routed
  through the fundamental wrapper (#465).
- Interface methods available directly on instances of private concrete types,
  e.g. `Gio.File.newForPath(...).getPath()` (#441).
- Nullable `char *` / array returns give `null` (not `""`/`[]`) at EOF, e.g.
  `DataInputStream.readLineFinish()` (#467).
- Dropped the `deasync` dev dependency; MSVC build strips Node 26's ThinLTO flags.

### This PR's diff

Version `3.0.0 → 4.0.0` (`package.json` + lockfile), the `v4.0.0` CHANGELOG
section, and the README supported-versions line. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)