### PR TITLE
fix: stop GApplication busy-spin at 100% CPU under ESM (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changes to be released are kept in the unreleased section.
 
 ## Unreleased
 
+## v4.0.1
+
+### Fixes
+
+- **A running `GApplication` no longer busy-spins at 100% CPU under ES modules**
+  (most visible on Node.js 26 / libuv 1.52). Under ESM the blocking `run()` is
+  deferred to a macrotask so pending Promise/async continuations keep draining
+  (#442); that deferral used `setImmediate`, whose callback runs inside Node's
+  immediate-processing machinery. Because `run()` never returns (it blocks in
+  the GLib main loop), Node never got the chance to stop its private immediate
+  `uv_idle` handle, which pinned `uv_backend_timeout()` at `0` and made the
+  nested uv-in-GLib loop spin, starving the app. The deferral now uses a
+  `setTimeout(…, 0)` macrotask, which leaves no libuv state active while it
+  blocks (#477).
+
 ## v4.0.0
 
 ### Breaking changes

--- a/lib/loop.js
+++ b/lib/loop.js
@@ -45,10 +45,22 @@ function start() {
  * macrotask lets the module's top-level microtask return first, so the queue
  * drains and the loop integration takes over from a clean (non-nested) state.
  *
+ * We defer with setTimeout, NOT setImmediate. A setImmediate callback runs
+ * *inside* Node's immediate-processing machinery (native CheckImmediate ->
+ * processImmediate). Because `run` never returns (it blocks in the GLib main
+ * loop until the app quits), CheckImmediate never reaches the code that stops
+ * Node's private immediate uv_idle handle, so that handle stays active forever.
+ * An active idle handle pins uv_backend_timeout() at 0, which makes the nested
+ * uv-in-GLib loop busy-spin at 100% CPU (worse on Node 26 / libuv 1.52, where
+ * the immediate's wakeup eventfd also stays signalled). A one-shot timer is
+ * removed from libuv's timer heap before its callback runs, so blocking inside
+ * it leaves no libuv state active and the loop can sleep normally. See #477.
+ *
  * Under CommonJS (and inside signal callbacks) we are not in a microtask, so we
  * run synchronously and preserve the original blocking semantics exactly.
  *
  * https://github.com/romgrk/node-gtk/issues/442
+ * https://github.com/romgrk/node-gtk/issues/477
  *
  * Returns the native call's result when run synchronously (so e.g.
  * `const status = app.run()` keeps working under CommonJS); returns undefined
@@ -64,7 +76,7 @@ function runLoopEntry(run) {
   start()
 
   if (internal.IsRunningMicrotasks()) {
-    setImmediate(run)
+    setTimeout(run, 0)
     return undefined
   }
   return run()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-gtk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GNOME Gtk+ bindings for NodeJS",
   "main": "lib/index.js",
   "exports": {

--- a/tests/loop__esm_idle_cpu.js
+++ b/tests/loop__esm_idle_cpu.js
@@ -1,0 +1,35 @@
+/*
+ * loop__esm_idle_cpu.js
+ *
+ * Regression test for #477: a running GApplication busy-spun at 100% CPU under
+ * ES modules (worst on Node 26 / libuv 1.52) because the deferred blocking
+ * run() ran inside Node's immediate machinery and leaked its idle handle.
+ * Spawns the ESM repro as a child process and asserts it stays at low CPU.
+ */
+
+const path = require('path')
+const child_process = require('child_process')
+const { assert } = require('./__common__')
+
+const child = path.join(__dirname, 'loop__esm_idle_cpu.mjs')
+
+/* When the bug is present the busy-spin also starves the child's own GLib
+ * timeout, so it never quits on its own -- a hard timeout is what surfaces the
+ * failure (SIGKILL because a spinning native loop ignores SIGTERM). A healthy
+ * run measures for ~1.5s and exits well within this window. */
+const result = child_process.spawnSync(process.execPath, [child], {
+  encoding: 'utf8',
+  timeout: 30 * 1000,
+  killSignal: 'SIGKILL',
+})
+
+process.stdout.write(result.stdout || '')
+process.stderr.write(result.stderr || '')
+
+if (result.signal)
+  assert(false, `an idle GApplication busy-spun under ESM (child killed by ${result.signal})`)
+
+assert(
+  result.status === 0,
+  `an idle GApplication should not busy-spin under ESM (child exited ${result.status})`
+)

--- a/tests/loop__esm_idle_cpu.mjs
+++ b/tests/loop__esm_idle_cpu.mjs
@@ -1,0 +1,58 @@
+/*
+ * loop__esm_idle_cpu.mjs
+ *
+ * A running GApplication must sit idle at low CPU, not busy-spin. Under ES
+ * modules the blocking run() is deferred to a macrotask; deferring it with
+ * setImmediate (as node-gtk used to) ran the never-returning blocking call
+ * inside Node's immediate machinery, which left Node's private immediate
+ * uv_idle handle active forever and busy-spun the nested uv-in-GLib loop at
+ * 100% CPU (worst on Node 26 / libuv 1.52). See #477.
+ *
+ * Run as a child process by loop__esm_idle_cpu.js. Uses Gio.Application (no
+ * display required, so it works headless in CI). Exits 0 on success.
+ */
+
+import { createRequire } from 'node:module'
+
+const gi = createRequire(import.meta.url)('..')
+const Gio = gi.require('Gio', '2.0')
+const GLib = gi.require('GLib', '2.0')
+
+const loop = GLib.MainLoop.new(null, false)
+const app = new Gio.Application('org.nodegtk.test.IdleCpu', 0)
+
+let cpuPercent = null
+
+app.on('activate', () => {
+  /* Keep the application alive with no window; this alone reproduced the spin. */
+  app.hold()
+
+  const cpuStart = process.cpuUsage()
+  const wallStart = Date.now()
+
+  /* Sample CPU after the loop has been idle for a while. */
+  GLib.timeoutAdd(GLib.PRIORITY_DEFAULT, 1500, () => {
+    const cpu = process.cpuUsage(cpuStart)
+    const wallMs = Date.now() - wallStart
+    cpuPercent = ((cpu.user + cpu.system) / 1000) / wallMs * 100
+    app.release()
+    loop.quit()
+    return GLib.SOURCE_REMOVE
+  })
+
+  loop.run()
+})
+
+/* Under ESM this returns immediately (the blocking call is deferred). */
+app.run()
+
+process.on('exit', () => {
+  /* The bug pins a core at ~100%; a correctly-sleeping loop stays near 0%.
+   * 50% is a wide margin that stays clear of both under CI load. */
+  if (cpuPercent === null || cpuPercent > 50) {
+    console.error(`FAIL: idle GApplication used ${cpuPercent && cpuPercent.toFixed(0)}% CPU (expected < 50%)`)
+    process.exitCode = 1
+    return
+  }
+  console.log(`OK: idle GApplication used ${cpuPercent.toFixed(0)}% CPU under ESM`)
+})


### PR DESCRIPTION
Fixes #477.

## Problem

Under ES modules, any running `GApplication` busy-spins at 100% CPU — the process pins a core while idle and the app never settles (window/D-Bus registration is starved). Most visible on Node 26 (libuv 1.52); Node 22 was only mildly affected. This made node-gtk 4.0.0 effectively unusable for GUI apps on current Node.

## Root cause

It's node-gtk's own ESM deferral, not a Node bug.

Under ESM the module top-level runs as a V8 microtask, so `runLoopEntry` (`lib/loop.js`) defers the blocking `run()` to a macrotask so pending Promise/async continuations keep draining (#442). That deferral used **`setImmediate(run)`**, and a `setImmediate` callback runs *inside* Node's immediate-processing machinery (native `CheckImmediate` → `processImmediate`).

Because `run()` never returns — it blocks in the GLib main loop until the app quits — `CheckImmediate` never reaches the line that stops Node's private immediate `uv_idle` handle:

```cpp
do { MakeCallback(… processImmediate …); }   // <- run() blocks here, never returns
while (has_outstanding());
if (ref_count() == 0) ToggleImmediateRef(false);   // <- never reached
```

An active idle handle pins `uv_backend_timeout()` at `0`, so node-gtk's nested uv-in-GLib GSource dispatches every iteration → 100% CPU, starving GTK. On Node 26 the immediate's wakeup eventfd is also left signalled, keeping the backend epoll fd perpetually readable. (This is why `process.getActiveResourcesInfo()` reports no `Immediate`: `processImmediate` already dequeued it before calling the never-returning callback.)

CommonJS was unaffected because it doesn't defer — it runs `run()` synchronously.

## Fix

Defer with **`setTimeout(run, 0)`** instead. A one-shot timer is removed from libuv's timer heap *before* its callback runs, so blocking inside it leaves no active libuv state and the loop sleeps normally. It's still a macrotask, so the #442 microtask-draining behaviour is preserved.

One line in `lib/loop.js`; no native changes.

## Verification

Measured idle CPU with the issue's repro across the support matrix (windowed `Gtk.Application`, windowless `Gio.Application` + `app.hold()`, `--import` and static-import ESM, CJS):

| Node | before | after |
| --- | --- | --- |
| 26.4.0 (uv 1.52) | ~100% | 0–2% |
| 24.16.0 (uv 1.52) | ~100% | 0–2% |
| 22.22.3 (uv 1.51) | ~2% | 0–2% |

- `#442` regression test (`loop__esm_microtasks`) still passes on all three — Promise/async continuations keep draining under the loop.
- New regression test `tests/loop__esm_idle_cpu` runs an idle `GApplication` under ESM and asserts it does not busy-spin (fails on the old `setImmediate` deferral, passes now).
- Full suite: 97 passing on Node 26 (the one failure is the pre-existing environmental `require.js`, missing system typelibs like `libgitg-1.0` — unaffected by this change).

Also bumps the version to **v4.0.1** and adds a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)