### PR TITLE
fix: ref transfer-full GObject returns from JS callbacks (use-after-free)

### DIFF
--- a/src/callback.cc
+++ b/src/callback.cc
@@ -220,6 +220,18 @@ void Callback::Execute (GIArgument *result, GIArgument **args, Callback *callbac
             Throw::InvalidReturnValue (&return_type_info, jsReturnValue);
             goto out;
         }
+
+        // When the callback's return value is transfer-full, the C caller takes
+        // ownership of it (e.g. GtkTreeListModelCreateModelFunc → GListModel).
+        // V8ToGIArgument only unwrapped the pointer, leaving node-gtk holding
+        // just its toggle ref; without the owning reference the caller "owns"
+        // that toggle ref, so no toggle-up fires, the wrapper stays weak, and
+        // once GC collects it the object is finalized while the caller still
+        // uses it — a use-after-free (e.g. gtk_tree_list_model_finalize
+        // disconnecting its items-changed handler from a freed child model).
+        // This is the return counterpart of the transfer-full IN argument.
+        if (g_callable_info_get_caller_owns(callback->info) == GI_TRANSFER_EVERYTHING)
+            TakeOwnershipForTransferFull(&return_type_info, result, -1);
     }
 
     // TODO: assess transferness of arguments & check if we need to free them

--- a/src/function.cc
+++ b/src/function.cc
@@ -527,10 +527,7 @@ Local<Value> FunctionCall (
                 // GskRenderNode): add the reference the callee will own (#468).
                 else if (direction == GI_DIRECTION_IN
                         && g_arg_info_get_ownership_transfer(&arg_info) == GI_TRANSFER_EVERYTHING) {
-                    CopyBoxedForTransferFullIn(&type_info, &callable_arg_values[i], param.length);
-                    RefObjectForTransferFullIn(&type_info, &callable_arg_values[i]);
-                    RefFundamentalForTransferFullIn(&type_info, &callable_arg_values[i]);
-                    RefVariantForTransferFullIn(&type_info, &callable_arg_values[i]);
+                    TakeOwnershipForTransferFull(&type_info, &callable_arg_values[i], param.length);
                 }
             }
 

--- a/src/value.cc
+++ b/src/value.cc
@@ -1702,6 +1702,14 @@ void RefObjectForTransferFullIn (GITypeInfo *type_info, GIArgument *arg) {
     g_base_info_unref(iface);
 }
 
+// Documented on the declaration in value.h.
+void TakeOwnershipForTransferFull (GITypeInfo *type_info, GIArgument *arg, long length) {
+    CopyBoxedForTransferFullIn(type_info, arg, length);
+    RefObjectForTransferFullIn(type_info, arg);
+    RefFundamentalForTransferFullIn(type_info, arg);
+    RefVariantForTransferFullIn(type_info, arg);
+}
+
 
 /*
  * GValue conversion functions

--- a/src/value.h
+++ b/src/value.h
@@ -52,6 +52,16 @@ void         CopyBoxedForTransferFullIn (GITypeInfo *type_info, GIArgument *arg,
 // under the callee once the wrapper is GC'd. See #439.
 void         RefObjectForTransferFullIn (GITypeInfo *type_info, GIArgument *arg);
 
+// Hand a transfer-full value its own reference for its new owner. A value whose
+// ownership transfers full — a transfer-full IN argument, or a transfer-full
+// callable return — is exactly one of boxed / GObject / fundamental / GVariant,
+// and the four per-kind helpers (CopyBoxedForTransferFullIn / RefObjectFor... /
+// RefFundamentalFor... / RefVariantFor...) each no-op for the other kinds. Runs
+// them all so the single call covers every kind. `length` is the element count
+// for a transfer-full C array of boxed pointers (-1 when not such an array).
+// See #439/#409/#468.
+void         TakeOwnershipForTransferFull (GITypeInfo *type_info, GIArgument *arg, long length);
+
 bool         CanConvertV8ToGIArgument (GITypeInfo *type_info, Local<Value> value, bool may_be_null);
 
 bool         V8ToGValue(GValue *gvalue, Local<Value> value, ResourceOwnership ownership = kNone);

--- a/tests/object__callback_return_transfer_full.js
+++ b/tests/object__callback_return_transfer_full.js
@@ -1,0 +1,86 @@
+/*
+ * object__callback_return_transfer_full.js
+ *
+ * Regression test for the transfer-full callback-return use-after-free.
+ *
+ * When a JS callback's return value is transfer-full, the C caller takes
+ * ownership of one reference (e.g. GtkTreeListModelCreateModelFunc returns a
+ * `(transfer full) GListModel`). node-gtk marshalled the return by unwrapping
+ * the pointer only, leaving itself holding just the wrapper's toggle ref — so
+ * the caller effectively "owned" that toggle ref. The refcount never accounted
+ * for the new owner, no toggle-up fired, the wrapper stayed weak, and once GC
+ * collected it the object was finalized while the caller still used it. In the
+ * wild this crashed in gtk_tree_list_model_finalize, disconnecting its
+ * items-changed handler from an already-freed per-row child model.
+ *
+ * This mirrors that exact path: a GtkTreeListModel whose create-func returns a
+ * fresh Gio.ListStore per expanded row. We keep the tree alive, drop every JS
+ * reference to the child models, and force GC. The tree still owns each child,
+ * so with the fix none are collected (their wrappers stay strong); with the bug
+ * they are finalized out from under the tree (and a later tree teardown would be
+ * a use-after-free). The IN-argument counterpart is object__* / #439.
+ */
+
+const gi = require('../lib/')
+const { describe } = require('./__common__.js')
+
+if (typeof global.gc !== 'function') {
+  console.error('test must run with --expose-gc')
+  process.exit(1)
+}
+
+const GObject = gi.require('GObject', '2.0')
+const Gio = gi.require('Gio', '2.0')
+
+let Gtk
+try {
+  Gtk = gi.require('Gtk', '4.0')
+} catch (e) {
+  console.log('Gtk 4.0 not available, skipping:', e.message)
+  process.exit(222) // the runner treats exit 222 as skip
+}
+
+describe('a transfer-full GObject returned from a callback is kept alive by the C owner', async () => {
+  const N = 100
+  let childCollected = 0
+  const registry = new FinalizationRegistry(() => { childCollected++ })
+
+  // Root model: N expandable rows.
+  const root = Gio.ListStore.new(GObject.TYPE_OBJECT)
+  for (let i = 0; i < N; i++)
+    root.append(new GObject.Object())
+
+  // The create-func hands GtkTreeListModel a fresh child model per row with
+  // `(transfer full)` ownership — the tree keeps it and connects items-changed.
+  // We register each child so we can observe whether GC reclaims it.
+  const tree = Gtk.TreeListModel.new(root, false, false, (_item) => {
+    const child = Gio.ListStore.new(GObject.TYPE_OBJECT)
+    registry.register(child)
+    return child // the only strong JS reference dies when this closure returns
+  })
+
+  // Expand every root row so the tree realizes (and retains) a child model for
+  // each — the same thing FileTree does on directory expand.
+  for (let i = 0; i < N; i++) {
+    const row = tree.getRow(i)
+    row.setExpanded(true)
+  }
+
+  // Drop every JS reference to the child models and force GC. The tree is still
+  // alive and owns each child, so a correctly-transferred reference keeps them
+  // from being finalized.
+  for (let g = 0; g < 12 && childCollected === 0; g++) {
+    global.gc()
+    await new Promise(r => setImmediate(r))
+  }
+
+  if (childCollected !== 0)
+    throw new Error(
+      `child models were finalized while the GtkTreeListModel still owns them: ` +
+      `${childCollected}/${N} collected — the transfer-full callback return did not ` +
+      `add the owning reference (use-after-free on tree teardown)`)
+
+  // Sanity: the tree is still usable and can be torn down without a UAF.
+  if (tree.getNItems() < N)
+    throw new Error(`expected at least ${N} rows, got ${tree.getNItems()}`)
+})


### PR DESCRIPTION
## Problem

When a JS callback's return value is **transfer-full**, the C caller takes ownership of one reference — e.g. [`GtkTreeListModelCreateModelFunc`](https://docs.gtk.org/gtk4/callback.TreeListModelCreateModelFunc.html) returns a `(transfer full) GListModel`. The callback return path (`Callback::Execute` in `src/callback.cc`) unwrapped the pointer with `V8ToGIArgument` but never accounted for the transfer:

```c
success = V8ToGIArgument(&return_type_info, result, jsRealReturnValue, ...);
// TODO: assess transferness of arguments & check if we need to free them
```

So node-gtk kept only the wrapper's toggle ref, and the caller effectively "owned" that toggle ref. The refcount never rose to reflect the new owner, no toggle-up fired, the wrapper stayed weak, and once GC collected it the object was **finalized while the caller was still using it**.

This is the return-value mirror of the transfer-full **IN-argument** bug already fixed for the normal call path (#439 / #409 / #468 via `RefObjectForTransferFullIn` etc.). The callback boundary was never given the same treatment.

## Real-world crash

Observed as an intermittent `SIGSEGV` in a GTK4 app whose file tree uses a `GtkTreeListModel` with a create-func that returns a fresh child `Gio.ListStore` per expanded directory. A child model's JS wrapper is GC'd; node-gtk's deferred `GObjectTeardownIdle` drops the last ref and frees it, while the tree still holds it. Later the tree is torn down and disconnects its `items-changed` handler from the freed child:

```
gtk_tree_list_model_finalize
 └ gtk_tree_list_model_clear_node → gtk_rb_tree_unref → …_free_deep
    └ gtk_tree_list_model_clear_node_children
       └ g_signal_handlers_disconnect_matched(freed_child_model, …, items_changed_cb)
          └ g_type_check_instance → SIGSEGV
```

Confirmed from the core dump (crash object = `GtkTreeListModel`, faulting child model refcount 0 / `g_class == NULL`).

## Fix

Add the owning reference on a transfer-full callback return, mirroring the IN-argument handling:

```c
if (g_callable_info_get_caller_owns(callback->info) == GI_TRANSFER_EVERYTHING) {
    CopyBoxedForTransferFullIn(&return_type_info, result, -1);
    RefObjectForTransferFullIn(&return_type_info, result);
    RefFundamentalForTransferFullIn(&return_type_info, result);
    RefVariantForTransferFullIn(&return_type_info, result);
}
```

This covers GObject, boxed (handed a copy so the wrapper's memory isn't double-freed), fundamental, and GVariant returns — the same set as the existing IN-argument path.

## Test

`tests/object__callback_return_transfer_full.js` builds a `GtkTreeListModel` whose create-func returns fresh `Gio.ListStore`s, drops every JS reference to them, and forces GC. The tree still owns each child, so:

- **with the fix:** `0/100` collected — wrappers stay strong ✅
- **without the fix:** `100/100` collected (the pre-fix failure) — child models finalized out from under the tree ❌

Skips cleanly (exit 222) where GTK4 isn't available. The 62 object/callback/signal/marshalling/vfunc/toggle-ref/gc tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)