### PR TITLE
fix: two crash-grade memory bugs — off-thread toggle notifications and transfer-none list IN element over-unref

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -36,6 +36,7 @@
                 "src/gobject.cc",
                 "src/loop.cc",
                 "src/param_spec.cc",
+                "src/toggle_queue.cc",
                 "src/type.cc",
                 "src/util.cc",
                 "src/value.cc",

--- a/src/callback.cc
+++ b/src/callback.cc
@@ -23,6 +23,9 @@ namespace GNodeJS {
 
 static guint callbackLevel = 0;
 static GSList* notifiedCallbacks = NULL;
+/* DestroyNotify can fire on any thread (e.g. a GTask freeing its callback
+ * data on a pool thread); the list must not race the JS thread's AsyncFree. */
+static GMutex notifiedCallbacksLock;
 
 static Local<Object> GetSelfInstance(GIArgument **args) {
     return WrapperFromGObject((GObject *)args[0]->v_pointer).As<Object>();
@@ -66,26 +69,27 @@ Callback::~Callback() {
  * we can't free the resources here. They'll be freed in Callback::AsyncFree.
  */
 void Callback::DestroyNotify (void* user_data) {
+    g_mutex_lock (&notifiedCallbacksLock);
     notifiedCallbacks = g_slist_prepend (notifiedCallbacks, user_data);
+    g_mutex_unlock (&notifiedCallbacksLock);
 }
 
 /**
  * Frees the callbacks that have been destroy-notified
  */
 void Callback::AsyncFree () {
-    if (notifiedCallbacks == NULL || callbackLevel > 0)
+    if (callbackLevel > 0)
         return;
 
-    GSList* current = notifiedCallbacks;
-
-    while (current != NULL) {
-        Callback* callback = static_cast<Callback*>(current->data);
-        delete callback;
-
-        current = current->next;
-    }
-
+    g_mutex_lock (&notifiedCallbacksLock);
+    GSList* list = notifiedCallbacks;
     notifiedCallbacks = NULL;
+    g_mutex_unlock (&notifiedCallbacksLock);
+
+    for (GSList* current = list; current != NULL; current = current->next)
+        delete static_cast<Callback*>(current->data);
+
+    g_slist_free (list);
 }
 
 /**

--- a/src/gi.cc
+++ b/src/gi.cc
@@ -32,6 +32,8 @@ namespace GNodeJS {
 
     Nan::Persistent<Object> moduleCache(Nan::New<Object>());
 
+    GThread *js_thread = NULL;
+
     Local<Object> GetModuleCache() {
         return Nan::New<Object>(GNodeJS::moduleCache);
     }
@@ -526,6 +528,8 @@ NAN_METHOD(CallVFunc) {
 }
 
 void InitModule(Local<Object> exports, Local<Value> module, void *priv) {
+    GNodeJS::js_thread = g_thread_self();
+
     GNodeJS::AsyncCallEnvironment::Initialize();
 
     Nan::Export(exports, "Bootstrap",            Bootstrap);

--- a/src/gi.h
+++ b/src/gi.h
@@ -24,6 +24,12 @@ namespace GNodeJS {
 
 extern Nan::Persistent<Object> moduleCache;
 
+/*
+ * The thread running V8/libuv (recorded at module init). V8 objects — global
+ * handles in particular — may only be touched from this thread.
+ */
+extern GThread *js_thread;
+
 Local<Object> GetModuleCache();
 
 /*

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -133,7 +133,100 @@ struct GObjectWrapper {
     bool collected = false;
 };
 
+/*
+ * Deferred processing for toggle notifications that fire off the JS thread.
+ *
+ * A toggle notification runs synchronously on whatever thread crosses the
+ * 1<->2 refcount boundary — e.g. GLib's worker thread dropping the ref it
+ * held on a GSubprocess while waiting for the child to exit. V8 global
+ * handles may only be touched from the JS thread: a SetWeak/ClearWeak from a
+ * worker raced the scavenger's weak-handle processing and corrupted the
+ * global-handle list (fatal "Check failed: Heap::InFromPage(heap_object)" in
+ * a later scavenge, or random SIGSEGV). Off-thread notifications are queued
+ * here and drained by an idle on the main context.
+ *
+ * The drain does not replay the queued direction — by then it is stale (the
+ * refcount may have crossed the boundary again, in either order). It
+ * re-derives the wanted handle state from the current refcount, which makes
+ * the deferral idempotent and ordering-insensitive.
+ *
+ * Queue entries hold no reference (taking one from inside a toggle handler
+ * would recursively fire the opposite toggle). A live wrapper's toggle ref
+ * keeps the object's refcount >= 1, so a queued object cannot be finalized
+ * under normal operation; as a safety net the GObjectFinalized weak callback
+ * and the wrapper teardown cancel any pending entry.
+ */
+static struct {
+    GMutex  lock;
+    GSList *objects;
+    guint   source;
+} toggle_queue;
+
+static gboolean DrainToggleQueue(gpointer user_data);
+
+static void QueueToggleSync(GObject *gobject) {
+    g_mutex_lock (&toggle_queue.lock);
+    if (g_slist_find (toggle_queue.objects, gobject) == NULL)
+        toggle_queue.objects = g_slist_prepend (toggle_queue.objects, gobject);
+    if (toggle_queue.source == 0)
+        toggle_queue.source = g_idle_add (DrainToggleQueue, NULL);
+    g_mutex_unlock (&toggle_queue.lock);
+}
+
+static void CancelToggleSync(GObject *gobject) {
+    g_mutex_lock (&toggle_queue.lock);
+    toggle_queue.objects = g_slist_remove (toggle_queue.objects, gobject);
+    g_mutex_unlock (&toggle_queue.lock);
+}
+
+/* Main thread only. Put the persistent in the state the current refcount
+ * calls for: weak when the toggle ref is the only reference left, strong
+ * otherwise. Mirrors the two branches of ToggleNotify. */
+static void SyncToggleState(GObject *gobject) {
+    void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
+    if (data == NULL)
+        return;
+
+    auto *wrapper = (GObjectWrapper *) data;
+    if (wrapper->collected)
+        return;
+
+    bool only_toggle_ref =
+        g_atomic_int_get ((const gint *) &gobject->ref_count) <= 1;
+
+    if (only_toggle_ref && !wrapper->dying) {
+        wrapper->dying = true;
+        wrapper->persistent.v8::PersistentBase<Object>::SetWeak (
+            wrapper, GObjectDestroyedFirstPass, v8::WeakCallbackType::kParameter);
+    } else if (!only_toggle_ref && wrapper->dying) {
+        wrapper->dying = false;
+        wrapper->persistent.ClearWeak ();
+    }
+}
+
+/* The lock is held across the drain so a (buggy, over-unreffed) off-thread
+ * finalize cancelling its entry cannot race the entry being processed.
+ * Nothing in SyncToggleState re-enters the queue, so this cannot deadlock. */
+static gboolean DrainToggleQueue(gpointer user_data) {
+    g_mutex_lock (&toggle_queue.lock);
+    GSList *objects = toggle_queue.objects;
+    toggle_queue.objects = NULL;
+    toggle_queue.source = 0;
+
+    for (GSList *l = objects; l != NULL; l = l->next)
+        SyncToggleState ((GObject *) l->data);
+
+    g_slist_free (objects);
+    g_mutex_unlock (&toggle_queue.lock);
+    return G_SOURCE_REMOVE;
+}
+
 static void ToggleNotify(gpointer user_data, GObject *gobject, gboolean toggle_down) {
+    if (G_UNLIKELY (g_thread_self () != GNodeJS::js_thread)) {
+        QueueToggleSync (gobject);
+        return;
+    }
+
     void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
 
     g_assert (data != NULL);
@@ -202,6 +295,9 @@ static void AssociateGObject(Local<Object> object, GObject *gobject, GType gtype
 static void GObjectFinalized(gpointer data, GObject *where_the_object_was) {
     auto *wrapper = (GObjectWrapper *) data;
     wrapper->gobject = NULL;
+    /* A deferred off-thread toggle may still be queued for this object; the
+     * drain must not touch freed memory. */
+    CancelToggleSync (where_the_object_was);
 }
 
 static void GObjectConstructor(const FunctionCallbackInfo<Value> &info) {
@@ -308,6 +404,11 @@ static gboolean GObjectTeardownIdle(gpointer data) {
     /* If the GObject was already finalized out from under us, GObjectFinalized
      * cleared the pointer; there is nothing left to detach or unref. */
     if (gobject != NULL) {
+        /* The weak ref that would cancel a queued off-thread toggle on
+         * finalize is removed below, so cancel any pending entry now — the
+         * toggle ref drop at the end may be the object's last reference. */
+        CancelToggleSync (gobject);
+
         /* Drop the weak ref first so removing the toggle ref (which may finalize
          * the object) doesn't re-enter GObjectFinalized. */
         g_object_weak_unref (gobject, GObjectFinalized, wrapper);

--- a/src/gobject.cc
+++ b/src/gobject.cc
@@ -11,6 +11,7 @@
 #include "gi.h"
 #include "gobject.h"
 #include "macros.h"
+#include "toggle_queue.h"
 #include "util.h"
 #include "value.h"
 
@@ -133,61 +134,34 @@ struct GObjectWrapper {
     bool collected = false;
 };
 
-/*
- * Deferred processing for toggle notifications that fire off the JS thread.
+/* Reconcile the wrapper's persistent with the state the object's current
+ * refcount calls for. Main thread only — called inline by ToggleNotify on the
+ * JS thread, and by toggleQueue's drain for deferred off-thread notifications.
  *
- * A toggle notification runs synchronously on whatever thread crosses the
- * 1<->2 refcount boundary — e.g. GLib's worker thread dropping the ref it
- * held on a GSubprocess while waiting for the child to exit. V8 global
- * handles may only be touched from the JS thread: a SetWeak/ClearWeak from a
- * worker raced the scavenger's weak-handle processing and corrupted the
- * global-handle list (fatal "Check failed: Heap::InFromPage(heap_object)" in
- * a later scavenge, or random SIGSEGV). Off-thread notifications are queued
- * here and drained by an idle on the main context.
+ * Weak when the toggle ref is the only reference left: we are the last
+ * holder, so the wrapper may be collected. The two-pass weak callback's first
+ * pass runs *during* GC (before any JS/GTK code resumes) and only flips a
+ * flag, so WrapperFromGObject can tell a reclaimed wrapper from a live one
+ * and never marshals a dead handle to JS. All GObject teardown happens in the
+ * second pass — a first-pass callback may not call into GObject.
  *
- * The drain does not replay the queued direction — by then it is stale (the
- * refcount may have crossed the boundary again, in either order). It
- * re-derives the wanted handle state from the current refcount, which makes
- * the deferral idempotent and ordering-insensitive.
- *
- * Queue entries hold no reference (taking one from inside a toggle handler
- * would recursively fire the opposite toggle). A live wrapper's toggle ref
- * keeps the object's refcount >= 1, so a queued object cannot be finalized
- * under normal operation; as a safety net the GObjectFinalized weak callback
- * and the wrapper teardown cancel any pending entry.
- */
-static struct {
-    GMutex  lock;
-    GSList *objects;
-    guint   source;
-} toggle_queue;
-
-static gboolean DrainToggleQueue(gpointer user_data);
-
-static void QueueToggleSync(GObject *gobject) {
-    g_mutex_lock (&toggle_queue.lock);
-    if (g_slist_find (toggle_queue.objects, gobject) == NULL)
-        toggle_queue.objects = g_slist_prepend (toggle_queue.objects, gobject);
-    if (toggle_queue.source == 0)
-        toggle_queue.source = g_idle_add (DrainToggleQueue, NULL);
-    g_mutex_unlock (&toggle_queue.lock);
-}
-
-static void CancelToggleSync(GObject *gobject) {
-    g_mutex_lock (&toggle_queue.lock);
-    toggle_queue.objects = g_slist_remove (toggle_queue.objects, gobject);
-    g_mutex_unlock (&toggle_queue.lock);
-}
-
-/* Main thread only. Put the persistent in the state the current refcount
- * calls for: weak when the toggle ref is the only reference left, strong
- * otherwise. Mirrors the two branches of ToggleNotify. */
-static void SyncToggleState(GObject *gobject) {
+ * Strong otherwise: something other than us holds the object, so the wrapper
+ * must stay alive until that ref is dropped again. Reviving is essential —
+ * without it a wrapper that went weak once (e.g. a freshly constructed object
+ * at refcount 1) would never become strong again when GTK takes ownership,
+ * and GC could then collect a wrapper whose GObject is still in use (notably
+ * a subclassed widget owned by GTK, losing its overridden vfuncs and instance
+ * state). */
+void SynchronizeToggleState(GObject *gobject) {
     void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
     if (data == NULL)
         return;
 
     auto *wrapper = (GObjectWrapper *) data;
+
+    /* The V8 handle has already been reclaimed by GC (collected) — it is dead
+     * and can be made neither weak nor strong. If the object is marshalled
+     * again, WrapperFromGObject builds a fresh wrapper. */
     if (wrapper->collected)
         return;
 
@@ -204,67 +178,22 @@ static void SyncToggleState(GObject *gobject) {
     }
 }
 
-/* The lock is held across the drain so a (buggy, over-unreffed) off-thread
- * finalize cancelling its entry cannot race the entry being processed.
- * Nothing in SyncToggleState re-enters the queue, so this cannot deadlock. */
-static gboolean DrainToggleQueue(gpointer user_data) {
-    g_mutex_lock (&toggle_queue.lock);
-    GSList *objects = toggle_queue.objects;
-    toggle_queue.objects = NULL;
-    toggle_queue.source = 0;
-
-    for (GSList *l = objects; l != NULL; l = l->next)
-        SyncToggleState ((GObject *) l->data);
-
-    g_slist_free (objects);
-    g_mutex_unlock (&toggle_queue.lock);
-    return G_SOURCE_REMOVE;
-}
-
+/* Fires synchronously on whatever thread crosses the 1<->2 refcount boundary
+ * — e.g. GLib's worker thread dropping the ref it held on a GSubprocess while
+ * waiting for the child to exit. V8 global handles may only be touched from
+ * the JS thread: a SetWeak/ClearWeak from a worker raced the scavenger's
+ * weak-handle processing and corrupted the global-handle list (fatal "Check
+ * failed: Heap::InFromPage(heap_object)" in a later scavenge, or random
+ * SIGSEGV). Off-thread notifications are deferred to the main context; the
+ * notified direction is not forwarded because the deferred reconciliation
+ * re-derives it from the refcount (see toggle_queue.h). */
 static void ToggleNotify(gpointer user_data, GObject *gobject, gboolean toggle_down) {
     if (G_UNLIKELY (g_thread_self () != GNodeJS::js_thread)) {
-        QueueToggleSync (gobject);
+        toggleQueue.Synchronize (gobject);
         return;
     }
 
-    void *data = g_object_get_qdata (gobject, GNodeJS::object_quark());
-
-    g_assert (data != NULL);
-
-    auto *wrapper = (GObjectWrapper *) data;
-
-    /* The V8 handle has already been reclaimed by GC (collected) — it is dead
-     * and can be made neither weak nor strong. If the object is marshalled
-     * again, WrapperFromGObject builds a fresh wrapper. */
-    if (wrapper->collected)
-        return;
-
-    if (toggle_down) {
-        /* We're dropping from 2 refs to 1 ref: we are the last holder, so the
-         * wrapper may be collected. Install the weak ref (unless it already is). */
-        if (wrapper->dying)
-            return;
-        wrapper->dying = true;
-        /* Two-pass weak callback: the first pass runs *during* GC (before any
-         * JS/GTK code resumes) and only flips a flag, so WrapperFromGObject can
-         * tell a reclaimed wrapper from a live one and never marshals a dead
-         * handle to JS. All GObject teardown happens in the second pass — a
-         * first-pass callback may not call into GObject. */
-        wrapper->persistent.v8::PersistentBase<Object>::SetWeak (
-            wrapper, GObjectDestroyedFirstPass, v8::WeakCallbackType::kParameter);
-    } else {
-        /* We're going from 1 ref to 2 refs: something other than us now holds
-         * the object, so the wrapper must stay alive (strong) until that ref is
-         * dropped again. Reviving here is essential — without it a wrapper that
-         * went weak once (e.g. a freshly constructed object at refcount 1) would
-         * never become strong again when GTK takes ownership, and GC could then
-         * collect a wrapper whose GObject is still in use (notably a subclassed
-         * widget owned by GTK, losing its overridden vfuncs and instance state). */
-        if (!wrapper->dying)
-            return;
-        wrapper->dying = false;
-        wrapper->persistent.ClearWeak ();
-    }
+    SynchronizeToggleState (gobject);
 }
 
 static void AssociateGObject(Local<Object> object, GObject *gobject, GType gtype) {
@@ -297,7 +226,7 @@ static void GObjectFinalized(gpointer data, GObject *where_the_object_was) {
     wrapper->gobject = NULL;
     /* A deferred off-thread toggle may still be queued for this object; the
      * drain must not touch freed memory. */
-    CancelToggleSync (where_the_object_was);
+    toggleQueue.Cancel (where_the_object_was);
 }
 
 static void GObjectConstructor(const FunctionCallbackInfo<Value> &info) {
@@ -407,7 +336,7 @@ static gboolean GObjectTeardownIdle(gpointer data) {
         /* The weak ref that would cancel a queued off-thread toggle on
          * finalize is removed below, so cancel any pending entry now — the
          * toggle ref drop at the end may be the object's last reference. */
-        CancelToggleSync (gobject);
+        toggleQueue.Cancel (gobject);
 
         /* Drop the weak ref first so removing the toggle ref (which may finalize
          * the object) doesn't re-enter GObjectFinalized. */

--- a/src/gobject.h
+++ b/src/gobject.h
@@ -18,6 +18,11 @@ namespace GNodeJS {
 MaybeLocal<Function>    MakeClass            (GIBaseInfo *info);
 Local<Value>            WrapperFromGObject   (GObject *object);
 GObject *               GObjectFromWrapper   (Local<Value> value);
+
+/* Reconcile the wrapper's V8 persistent (weak or strong) with the GObject's
+ * current refcount. Main thread only; called inline by ToggleNotify on the JS
+ * thread and by toggleQueue's drain for deferred off-thread notifications. */
+void                    SynchronizeToggleState (GObject *gobject);
 Local<Value>            GetSignalHandler     (GObject *gobject, guint index);
 Local<FunctionTemplate> GetBaseClassTemplate ();
 MaybeLocal<Value>       GetGObjectProperty   (GObject * gobject, const char *prop_name);

--- a/src/toggle_queue.cc
+++ b/src/toggle_queue.cc
@@ -1,0 +1,44 @@
+
+#include "toggle_queue.h"
+#include "gobject.h"
+
+namespace GNodeJS {
+
+ToggleQueue toggleQueue;
+
+void ToggleQueue::Synchronize (GObject *gobject) {
+    g_mutex_lock (&lock);
+    if (g_slist_find (objects, gobject) == NULL)
+        objects = g_slist_prepend (objects, gobject);
+    if (source == 0)
+        source = g_idle_add (ToggleQueue::Drain, this);
+    g_mutex_unlock (&lock);
+}
+
+void ToggleQueue::Cancel (GObject *gobject) {
+    g_mutex_lock (&lock);
+    objects = g_slist_remove (objects, gobject);
+    g_mutex_unlock (&lock);
+}
+
+/* Runs on the main context. The lock is held across the drain so a (buggy,
+ * over-unreffed) off-thread finalize cancelling its entry cannot race the
+ * entry being processed. SynchronizeToggleState never re-enters the queue,
+ * so this cannot deadlock. */
+gboolean ToggleQueue::Drain (gpointer user_data) {
+    auto *self = static_cast<ToggleQueue *> (user_data);
+
+    g_mutex_lock (&self->lock);
+    GSList *objects = self->objects;
+    self->objects = NULL;
+    self->source = 0;
+
+    for (GSList *l = objects; l != NULL; l = l->next)
+        SynchronizeToggleState ((GObject *) l->data);
+
+    g_slist_free (objects);
+    g_mutex_unlock (&self->lock);
+    return G_SOURCE_REMOVE;
+}
+
+}; /* GNodeJS */

--- a/src/toggle_queue.h
+++ b/src/toggle_queue.h
@@ -1,0 +1,53 @@
+
+#pragma once
+
+#include <glib-object.h>
+
+namespace GNodeJS {
+
+/*
+ * Defers toggle-state synchronization to the main context.
+ *
+ * "Synchronize" is meant as reconcile — bring the wrapper's V8 persistent
+ * (weak or strong) in line with the GObject's current refcount — not as
+ * synchronous execution: requests may come from any thread, and the
+ * reconciliation itself always runs later, from an idle on the main context.
+ *
+ * A toggle notification runs on whatever thread crosses the 1<->2 refcount
+ * boundary, but V8 global handles may only be touched from the JS thread
+ * (see ToggleNotify in gobject.cc). Off-thread notifications land here.
+ *
+ * The queue stores no direction: by the time the idle runs, the notified
+ * direction is stale (the refcount may have crossed the boundary again, in
+ * either order). Each drained object is instead reconciled from its current
+ * refcount (SynchronizeToggleState), which makes the deferral idempotent and
+ * ordering-insensitive.
+ *
+ * Entries hold no reference (taking one from inside a toggle handler would
+ * recursively fire the opposite toggle). A live wrapper's toggle ref keeps
+ * the object's refcount >= 1, so a queued object cannot be finalized under
+ * normal operation; as a safety net the GObjectFinalized weak callback and
+ * the wrapper teardown Cancel() any pending entry.
+ */
+class ToggleQueue {
+public:
+    /* Request a deferred synchronization of the object's toggle state.
+     * Callable from any thread. */
+    void Synchronize (GObject *gobject);
+
+    /* Drop the object's pending synchronization, if any. Callable from any
+     * thread. Must be called before the object can be finalized, so the
+     * drain never touches freed memory. */
+    void Cancel (GObject *gobject);
+
+private:
+    static gboolean Drain (gpointer user_data);
+
+    GMutex  lock;
+    GSList *objects;
+    guint   source;
+};
+
+extern ToggleQueue toggleQueue;
+
+}; /* GNodeJS */

--- a/src/value.cc
+++ b/src/value.cc
@@ -1293,15 +1293,24 @@ void FreeGIArgument(GITypeInfo *type_info, GIArgument *arg, GITransfer transfer,
         if (free_elements) {
             GITypeInfo *element_info = g_type_info_get_param_type(type_info, 0);
 
-            GITransfer  element_transfer  = GI_TRANSFER_EVERYTHING;
-            GIDirection element_direction = GI_DIRECTION_OUT;
+            /* Free elements in the direction they were allocated: an
+             * OUT/EVERYTHING list transferred us one reference per element,
+             * released here (the wrappers hold their own). An IN list was
+             * built by V8ToGIArgument, which allocates strings but borrows
+             * GObject/boxed pointers straight from their wrappers — freeing
+             * with IN/NOTHING releases the strings and leaves the borrowed
+             * pointers alone (mirrors FreeGIArgumentArray). Unreffing IN
+             * elements stole a reference per element from their real owners
+             * (e.g. Gdk.FileList.newFromList: the GFiles were finalized while
+             * the GdkFileList's deep copy still pointed at them). */
+            GITransfer  element_transfer  = is_in ? GI_TRANSFER_NOTHING : GI_TRANSFER_EVERYTHING;
             GIArgument  element_arg;
 
             GSList* list = (GSList *)arg->v_pointer;
 
             for (; list != NULL; list = list->next) {
                 element_arg.v_pointer = list->data;
-                FreeGIArgument(element_info, &element_arg, element_transfer, element_direction);
+                FreeGIArgument(element_info, &element_arg, element_transfer, direction);
             }
 
             g_base_info_unref(element_info);

--- a/tests/value__list_in_transfer_none.js
+++ b/tests/value__list_in_transfer_none.js
@@ -1,0 +1,52 @@
+/*
+ * value__list_in_transfer_none.js
+ *
+ * Regression test for the transfer-none list IN-argument element over-unref.
+ *
+ * A transfer-none GList/GSList IN argument borrows its elements: node-gtk
+ * builds the temporary list from the wrappers' pointers without adding any
+ * reference, so it must not unref the elements when it frees the list after
+ * the call. FreeGIArgument used to free list elements with OUT/EVERYTHING
+ * semantics, calling g_object_unref on every GObject element — stealing one
+ * reference per element from their real owners.
+ *
+ * In the wild (mariner file manager): Gdk.FileList.newFromList(files) stole a
+ * ref from every GFile on each drag; the files were finalized while the drag's
+ * GdkContentProvider still held them, and dropping the provider crashed in
+ * g_object_unref on freed memory (SIGSEGV in
+ * g_type_check_instance_is_fundamentally_a).
+ */
+
+const gi = require('../lib/')
+const { describe, it, expect } = require('./__common__.js')
+
+let Gdk
+try {
+  Gdk = gi.require('Gdk', '4.0')
+} catch (e) {
+  console.log('Gdk 4.0 not available, skipping:', e.message)
+  process.exit(222) // the runner treats exit 222 as skip
+}
+
+const Gio = gi.require('Gio', '2.0')
+
+describe('transfer-none list IN argument', () => {
+  it('does not steal references from the elements', () => {
+    const file = Gio.File.newForPath('/tmp/node-gtk-test-a')
+
+    // The wrapper's toggle ref is the only reference.
+    expect(gi.System.refCount(file), 1)
+
+    // gdk_file_list_new_from_list(files: transfer-none GSList<GFile>) deep
+    // copies the list, adding one ref per file: the file is now owned by its
+    // wrapper and by the GdkFileList. Before the fix, node-gtk then unref'd
+    // each element while freeing its temporary GSList, stealing the reference
+    // the copy just took — leaving the file one GC away from use-after-free.
+    const list = Gdk.FileList.newFromList([file])
+
+    expect(gi.System.refCount(file), 2)
+
+    // Keep the list (and its references) alive until here.
+    expect(list.getFiles().length, 1)
+  })
+})


### PR DESCRIPTION
Fixes two independent crashes observed in the wild (mariner file manager on node-gtk 4.1.0, Node 26.4.0), both diagnosed from core dumps.

## 1. Off-thread toggle notifications corrupt V8 global handles

**Crash:** at app startup, mid array marshal:

```
Fatal error: Check failed: Heap::InFromPage(heap_object)
  GlobalHandlesWeakRootsUpdatingVisitor::UpdatePointer (v8 scavenger.cc:941)
  GlobalHandles::ProcessWeakYoungObjects
```

**Cause:** a toggle notification runs synchronously on whatever thread crosses the 1↔2 refcount boundary — e.g. GLib's worker thread dropping the ref it held on a `GSubprocess` while waiting for the child to exit. `ToggleNotify` then called `SetWeak`/`ClearWeak` on the wrapper's persistent from that thread, racing the JS thread's GC. Reproduced deterministically with a harness spawning `du` subprocesses and reading their stdout under `--gc-interval=500 --max-semi-space-size=1`: every subprocess reap fires `ToggleNotify(GSubprocess, down=1)` on a non-JS thread (caught with a thread-check instrumentation build).

**Fix:** off-thread notifications are queued (mutex-protected, deduplicated) and drained by an idle on the main context. The drain re-derives the wanted handle state from the current refcount instead of replaying the queued direction, which is stale by then — this makes the deferral idempotent and ordering-insensitive. Entries hold no reference (reffing inside a toggle handler recursively fires the opposite toggle); a live wrapper's toggle ref keeps a queued object alive, and `GObjectFinalized` plus the wrapper teardown cancel pending entries as a safety net. This is the same hazard GJS defends against with its ToggleQueue.

The destroy-notified callback list gets a mutex for the same reason — `Callback::DestroyNotify` can fire on a pool thread, and the unlocked `g_slist_prepend` raced `AsyncFree` (which also leaked its list nodes; freed now).

## 2. Transfer-none list IN arguments steal a reference per element

**Crash:** SIGSEGV in `g_type_check_instance_is_fundamentally_a` via `g_object_unref` ← `g_slist_free_full` ← `g_value_unset` ← `gdk_content_provider_value_finalize` ← `g_object_remove_toggle_ref` (wrapper teardown).

**Cause:** `FreeGIArgument` freed GList/GSList elements with OUT/`TRANSFER_EVERYTHING` semantics regardless of the argument's direction, so a transfer-none IN list of GObjects had every element unref'd — a reference node-gtk never took. Every drag in mariner calls `Gdk.FileList.newFromList(files)`; each call stole one ref per GFile, the files were finalized while the drag's `GdkContentProviderValue` still held them, and finalizing the provider crashed on the freed objects.

**Fix:** free elements in the direction they were allocated, mirroring `FreeGIArgumentArray`: OUT keeps `EVERYTHING` (releasing the refs transferred to us), IN uses `NOTHING` — which still frees the strings `V8ToGIArgument` strdup'd and leaves borrowed GObject/boxed pointers alone.

**Test:** `tests/value__list_in_transfer_none.js` asserts via `System.refCount` that the `GdkFileList` deep copy's reference survives the call (1 instead of 2 before the fix; fails on master, passes here).

## Validation

- Full test suite passes (100 passing; `require.js` fails identically on master — pre-existing GIRepository 2.0/3.0 typelib conflict on Arch).
- du-subprocess harness runs clean under GC stress; instrumented build shows 40/40 off-thread toggles deferred and drained.
- 25 GC-stressed startups of the affected app, plus normal interactive use: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)