### PR TITLE
Shrink install footprint: strip prebuilts (-90%) + drop unused deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,9 @@
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.3",
         "lodash.camelcase": "4.3.0",
-        "lodash.isequal": "4.5.0",
         "lodash.snakecase": "^4.1.1",
         "nan": "^2.27.0",
-        "node-gyp": "^11.2.0",
-        "remove-trailing-spaces": "^1.0.7",
-        "unindent": "^2.0.0"
+        "node-gyp": "^11.2.0"
       },
       "bin": {
         "node-gtk": "bin/node-gtk.js"
@@ -27,7 +24,8 @@
         "aws-sdk": "^2.1692.0",
         "chalk": "^2.4.2",
         "mocha": "^11.7.0",
-        "nid-parser": "0.0.5"
+        "nid-parser": "0.0.5",
+        "remove-trailing-spaces": "^1.0.7"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1340,13 +1338,6 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
@@ -2069,6 +2060,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.9.tgz",
       "integrity": "sha512-xzG7w5IRijvIkHIjDk65URsJJ7k4J95wmcArY5PRcmjldIOl7oTvG8+X2Ag690R7SfwiOcHrWZKVc1Pp5WIOzA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -2403,12 +2395,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/unindent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unindent/-/unindent-2.0.0.tgz",
-      "integrity": "sha512-Mo5gKmshwTR3b2BwCSMish/UuwTqP5W7TIRa88HQTydH+07HhkOCE1P6HZ4lSxJS5klEqXFnhlZSxkxbBOMk4Q==",
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -53,19 +53,17 @@
   "dependencies": {
     "@mapbox/node-pre-gyp": "^2.0.3",
     "lodash.camelcase": "4.3.0",
-    "lodash.isequal": "4.5.0",
     "lodash.snakecase": "^4.1.1",
     "nan": "^2.27.0",
-    "node-gyp": "^11.2.0",
-    "remove-trailing-spaces": "^1.0.7",
-    "unindent": "^2.0.0"
+    "node-gyp": "^11.2.0"
   },
   "devDependencies": {
     "assert": "^1.5.0",
     "aws-sdk": "^2.1692.0",
     "chalk": "^2.4.2",
     "mocha": "^11.7.0",
-    "nid-parser": "0.0.5"
+    "nid-parser": "0.0.5",
+    "remove-trailing-spaces": "^1.0.7"
   },
   "overrides": {
     "nid-parser": {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -19,8 +19,38 @@ if [[ ${COMMIT_MESSAGE} =~ "[skip tests]" ]]; then
 fi;
 
 
+# The Linux Release build embeds full DWARF debug info (binding.gyp passes -g so
+# a local `npm run build` stays debuggable), which balloons the addon from
+# ~0.5MB to ~5MB. Strip the packaged copy — and only that copy, right before
+# `node-pre-gyp package` archives it — so every user's download shrinks ~90%
+# while local builds keep their symbols.
+function strip_binaries() {
+    echo "### Stripping prebuilt ###"
+    local os
+    os=$(uname -s)
+    for f in lib/binding/*/node_gtk.node; do
+        [[ -e "$f" ]] || continue
+        local before after
+        before=$(wc -c < "$f")
+        if [[ $os == 'Darwin' ]]; then
+            strip -x "$f";
+        else
+            strip --strip-unneeded "$f";
+        fi
+        after=$(wc -c < "$f")
+        echo "  $f: ${before} -> ${after} bytes"
+    done
+
+    # Stripping runs after the test job, so a strip that produced an unloadable
+    # addon would otherwise ship unnoticed. Smoke-test the stripped binary here;
+    # `set -e` aborts the publish if it can no longer be loaded.
+    node -e "require('./lib/index.js').require('GLib', '2.0')"
+    echo "  stripped addon loads OK"
+}
+
 function publish() {
     echo "### Publish ###"
+    strip_binaries
     if [[ $PUBLISH_BINARIES == true ]]; then
         npx node-pre-gyp package testpackage;
         npx node-pre-gyp publish;

--- a/tests/__common__.js
+++ b/tests/__common__.js
@@ -3,7 +3,7 @@
  */
 
 const chalk = require('chalk')
-const isEqual = require('lodash.isequal')
+const { isDeepStrictEqual } = require('node:util')
 
 module.exports = {
   assert,
@@ -38,7 +38,7 @@ function isntUndefined(value, message) {
 }
 
 function expect(value, expected) {
-  assert(isEqual(value, expected),
+  assert(isDeepStrictEqual(value, expected),
     `Expected: "${expected}", got: "${value}"`)
   return value
 }


### PR DESCRIPTION
## Context

Investigated startup time for the hello-world example. Key finding: **node-gtk's controllable startup is only ~55ms of the ~385ms real hello-world startup** — the rest is Node itself (~17ms), GTK/libadwaita init (~55ms), and first-frame/compositor rendering (~180ms). The binding layer is already well-optimized by the prior lazy-GIR work, and the one thing that looked like free time — the ~31ms of eager GType registration in `GetInfoEntries` — is **load-bearing**: skipping it made real startup ~20ms *slower* (it just moves the cost onto widget construction). So there's no meaningful startup win left to take there.

What the investigation *did* surface are two real footprint wins, which is what this PR does. Neither changes runtime behavior or measurably affects startup — they reduce **install/download size and dependency surface**.

## 1. Strip prebuilt binaries (`ci: …`)

The Linux Release build ships **unstripped with full DWARF** (`binding.gyp` passes `-g` so local crashes stay debuggable), so the published addon is ~5.1 MB. This strips the packaged copy in `publish()` — only that copy, right before `node-pre-gyp package` — so local `npm run build` keeps its symbols while the prebuilt users download shrinks:

| | before | after |
|---|--:|--:|
| `.node` binary | 5,096,472 B | 537,600 B (**−89%**) |
| download (`.tar.gz`) | 1,885,792 B | 163,225 B (**−91%**) |

DWARF lives in non-loaded `.debug_*` sections, so this is a pure download/install win — `dlopen` is unchanged (~2.5→2.2ms). A post-strip smoke test loads the stripped addon so a bad strip aborts the publish instead of shipping something unloadable.

_Scope note:_ only Linux/macOS (`scripts/ci.sh`). The Windows build is MSVC (debug info → separate `.pdb`, not shipped) and bundles the full GTK runtime, so the `.node` strip there is negligible — left as a possible follow-up.

## 2. Drop unused runtime dependencies (`build: …`)

Verified by grepping every `require()` across `lib/`, `bin/`, `src/`, `tools/`, `tests/`:

- **`unindent`** — entirely unused; the cairo generators use a local `src/modules/cairo/indent.js`, not this package. Removed.
- **`lodash.isequal`** — only the test harness used it. Replaced with `node:util`'s built-in `isDeepStrictEqual`. Removed.
- **`remove-trailing-spaces`** — only the build-time cairo code generators use it (and their output is committed). Moved to `devDependencies`.

Removes 3 packages (+ transitive) from every consumer install, zero runtime behavior change. (Only `lodash.camelcase`/`lodash.snakecase` actually load at startup — ~1.3ms combined — so deps were never a startup factor.)

## Verification

- Full suite: **96 passing**. The single `require.js` failure ("some modules failed to load") is **pre-existing and environment-specific** (system Peas/PeasGtk typelibs) — reproduces identically on clean `master`, unrelated to these changes.
- `isDeepStrictEqual` swap: all `expect()`-based tests pass.
- Strip: built from source → stripped → **addon still loads** (`Gtk.Box`/`Window` resolve) → `node-pre-gyp package` succeeds; tarball 11.5× smaller.
- `bash -n scripts/ci.sh` clean; `strip_binaries` verified idempotent with smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)