### PR TITLE
feat: auto-box raw JS values into GValue-typed parameters

### DIFF
--- a/src/value.cc
+++ b/src/value.cc
@@ -827,6 +827,71 @@ item_error:
     return hash_table;
 }
 
+/* Guesses the GType a raw JS value should be boxed into when it is passed for
+ * a GValue-typed parameter, mirroring GJS's guessing (#469). Returns
+ * G_TYPE_INVALID when there is no sensible choice. */
+static GType GuessGValueType(Local<Value> value) {
+    if (value->IsBoolean())
+        return G_TYPE_BOOLEAN;
+    if (value->IsInt32())
+        return G_TYPE_INT;
+    if (value->IsNumber())
+        return G_TYPE_DOUBLE;
+    if (value->IsBigInt())
+        return G_TYPE_INT64;
+    if (value->IsString())
+        return G_TYPE_STRING;
+    if (ValueHasInternalField(value)) {
+        GType gtype = GET_OBJECT_GTYPE (TO_OBJECT (value));
+        // Restrict to what V8ToGValue can hold: other wrapped types
+        // (fundamentals, unregistered structs) have no GValue representation.
+        if (gtype != NOT_A_GTYPE
+                && (g_type_is_a (gtype, G_TYPE_OBJECT)
+                 || g_type_is_a (gtype, G_TYPE_BOXED)
+                 || g_type_is_a (gtype, G_TYPE_VARIANT)
+                 || g_type_is_a (gtype, G_TYPE_PARAM)))
+            return gtype;
+    }
+    return G_TYPE_INVALID;
+}
+
+/* A GValue-typed parameter given something other than a GObject.Value: box
+ * the raw JS value into a temporary GValue, as GJS does (#469). A callee that
+ * keeps the value past the call must copy it (a GValue parameter is
+ * transfer-none), so the temporary only needs to outlive the call: a
+ * throwaway owning wrapper keeps it alive through the surrounding HandleScope
+ * and g_boxed_free's it on GC. */
+static bool AutoBoxGValue(GIBaseInfo *gi_info, GIArgument *arg, Local<Value> value) {
+    GType guessed_type = GuessGValueType (value);
+
+    if (guessed_type == G_TYPE_INVALID) {
+        auto maybeDetailString = Nan::ToDetailString(value);
+        Nan::Utf8String utf8String(
+            !maybeDetailString.IsEmpty() ?
+                maybeDetailString.ToLocalChecked() :
+                UTF8("[invalid value]")
+        );
+        Throw::TypeError("Cannot auto-box value \"%s\" into a GObject.Value: "
+                "no GValue type for it", *utf8String);
+        return false;
+    }
+
+    GValue gvalue = G_VALUE_INIT;
+    g_value_init (&gvalue, guessed_type);
+
+    if (!V8ToGValue (&gvalue, value, kNone)) {
+        g_value_unset (&gvalue);
+        return false;
+    }
+
+    GValue *boxed = (GValue *) g_boxed_copy (G_TYPE_VALUE, &gvalue);
+    g_value_unset (&gvalue);
+
+    arg->v_pointer = boxed;
+    WrapperFromBoxed (gi_info, boxed, kTransfer);
+    return true;
+}
+
 bool V8ToGIArgumentInterface(GIBaseInfo *gi_info, GIArgument *arg, Local<Value> value) {
     GIInfoType type = g_base_info_get_type (gi_info);
 
@@ -836,6 +901,10 @@ bool V8ToGIArgumentInterface(GIBaseInfo *gi_info, GIArgument *arg, Local<Value> 
     case GI_INFO_TYPE_BOXED:
     case GI_INFO_TYPE_STRUCT:
     case GI_INFO_TYPE_UNION:
+        // A GValue-typed parameter also accepts a raw JS value (#469).
+        if (g_registered_type_info_get_g_type (gi_info) == G_TYPE_VALUE
+                && !ValueIsInstanceOfGType (value, G_TYPE_VALUE))
+            return AutoBoxGValue (gi_info, arg, value);
         arg->v_pointer = PointerFromWrapper(value);
         break;
 
@@ -1172,9 +1241,15 @@ bool CanConvertV8ToGIArgument(GITypeInfo *type_info, Local<Value> value, bool ma
             case GI_INFO_TYPE_INTERFACE:
             case GI_INFO_TYPE_BOXED:
             case GI_INFO_TYPE_STRUCT:
-            case GI_INFO_TYPE_UNION:
-                result = ValueIsInstanceOfGType (value, g_registered_type_info_get_g_type (interface_info));
+            case GI_INFO_TYPE_UNION: {
+                GType gtype = g_registered_type_info_get_g_type (interface_info);
+                result = ValueIsInstanceOfGType (value, gtype);
+                // A GValue-typed parameter also accepts any raw JS value that
+                // can be auto-boxed into a GValue (GJS parity, #469).
+                if (!result && gtype == G_TYPE_VALUE)
+                    result = GuessGValueType (value) != G_TYPE_INVALID;
                 break;
+            }
             case GI_INFO_TYPE_FLAGS:
             case GI_INFO_TYPE_ENUM:
                 result = value->IsNumber();

--- a/tests/conversion__gvalue_autobox.js
+++ b/tests/conversion__gvalue_autobox.js
@@ -1,0 +1,99 @@
+/*
+ * conversion__gvalue_autobox.js
+ *
+ * A GValue-typed method parameter accepts a raw JS value: it is auto-boxed
+ * into a temporary GValue, as GJS does (#469). The GValue type is guessed
+ * from the JS value (boolean/int/double/string, or the wrapped instance's
+ * own GType), and callees relying on g_value_transform (e.g.
+ * g_object_set_property, adw_breakpoint_add_setter) coerce it to the exact
+ * property type from there.
+ */
+
+const gi = require('../lib/')
+const GObject = gi.require('GObject', '2.0')
+const Gtk = gi.require('Gtk', '3.0')
+const Gdk = gi.require('Gdk', '3.0')
+const Pango = gi.require('Pango')
+const { describe, expect, it, mustThrow } = require('./__common__.js')
+
+Gtk.init([])
+
+// GObject.Object.prototype._setProperty is the raw introspected
+// g_object_set_property(name, GValue) method (the unprefixed setProperty is
+// overridden in lib/overrides/GObject.js and doesn't take a GValue).
+
+describe('GValue-typed parameters auto-box raw JS values', () => {
+  const label = new Gtk.Label()
+
+  it('boxes a boolean', () => {
+    label._setProperty('visible', true)
+    expect(label.visible, true)
+  })
+
+  it('boxes an integer number', () => {
+    label._setProperty('lines', 3)
+    expect(label.lines, 3)
+  })
+
+  it('boxes a float number', () => {
+    label._setProperty('angle', 45.5)
+    expect(label.angle, 45.5)
+  })
+
+  it('boxes a string', () => {
+    label._setProperty('label', 'hello')
+    expect(label.label, 'hello')
+  })
+
+  it('boxes an enum value', () => {
+    label._setProperty('justify', Gtk.Justification.RIGHT)
+    expect(label.justify, Gtk.Justification.RIGHT)
+  })
+
+  it('boxes a flags value', () => {
+    // GtkLabel is a no-window widget and won't retain 'events'.
+    const box = new Gtk.EventBox()
+    box._setProperty('events', Gdk.EventMask.KEY_PRESS_MASK)
+    expect(box.events, Gdk.EventMask.KEY_PRESS_MASK)
+  })
+
+  it('boxes a GObject instance', () => {
+    const other = new Gtk.Label()
+    label._setProperty('mnemonic-widget', other)
+    expect(label.mnemonicWidget === other, true)
+  })
+
+  it('boxes a boxed instance', () => {
+    const attrs = new Pango.AttrList()
+    attrs.insert(Pango.attrScaleNew(2))
+    label._setProperty('attributes', attrs)
+    expect(label.attributes instanceof Pango.AttrList, true)
+  })
+
+  it('still accepts an explicit GObject.Value', () => {
+    const value = new GObject.Value()
+    value.init(GObject.TYPE_BOOLEAN)
+    value.setBoolean(false)
+    label._setProperty('visible', value)
+    expect(label.visible, false)
+  })
+
+  it('works through Gtk.ListStore.setValue', () => {
+    const store = new Gtk.ListStore()
+    store.setColumnTypes([GObject.TYPE_STRING, GObject.TYPE_INT, GObject.TYPE_BOOLEAN, GObject.TYPE_DOUBLE])
+    const iter = store.append()
+    store.setValue(iter, 0, 'world')
+    store.setValue(iter, 1, 42)
+    store.setValue(iter, 2, true)
+    store.setValue(iter, 3, 3.25)
+    expect(store.getValue(iter, 0).getString(), 'world')
+    expect(store.getValue(iter, 1).getInt(), 42)
+    expect(store.getValue(iter, 2).getBoolean(), true)
+    expect(store.getValue(iter, 3).getDouble(), 3.25)
+  })
+
+  it('rejects a value it cannot box',
+    mustThrow(/Expected argument of type GObject.Value for parameter value/, () => {
+      label._setProperty('visible', {})
+    }))
+})


### PR DESCRIPTION
Closes #469.

Methods with a `GValue`-typed parameter (e.g. `Adw.Breakpoint.add_setter`) required hand-boxing a `GObject.Value`. This accepts raw JS values there and boxes them into a temporary `GValue`, as GJS does.

```js
bp.addSetter(label, 'visible', false)                   // now works
bp.addSetter(label, 'lines', 3)                         // now works
bp.addSetter(label, 'justify', Gtk.Justification.RIGHT) // now works
```

## How

All in `src/value.cc`:

- `GuessGValueType()` mirrors GJS's guessing (`gjs_value_guess_g_type`): boolean → `G_TYPE_BOOLEAN`, int32 number → `G_TYPE_INT`, other number → `G_TYPE_DOUBLE`, BigInt → `G_TYPE_INT64`, string → `G_TYPE_STRING`; a wrapped instance uses its own GType (restricted to GObject/boxed/GVariant/GParamSpec, the kinds `V8ToGValue` can hold). Anything else keeps the existing descriptive `TypeError` from `TypeCheck`.
- `AutoBoxGValue()` boxes the value into a heap `GValue`. Lifetime: the function-call cleanup pass intentionally frees nothing for boxed IN-args (the pointer normally belongs to a wrapper), so the temporary is owned by a throwaway `WrapperFromBoxed(..., kTransfer)` wrapper — alive through the call's HandleScope, freed by the normal boxed finalizer at GC. Callees that keep the value must copy it anyway (`const GValue*` is transfer-none).
- Both `V8ToGIArgumentInterface` and `CanConvertV8ToGIArgument` hook in only when the parameter's gtype is exactly `G_TYPE_VALUE`; existing `GObject.Value` wrappers pass through untouched.

Enum/flags properties work from raw numbers because callees (`adw_breakpoint_add_setter`, `g_object_set_property`, `gtk_list_store_set_value`) run `g_value_transform` into the target type, and GLib registers int→enum / int→flags transforms (verified empirically). Where no transform exists, adw raises an immediate error naming both types — no silent wrong-typed `GValue`.

Per @hiSandog's comment: property-pspec-directed inference can't live in the generic marshaller (the pspec↔parameter relationship isn't expressed in GIR, and e.g. `ListStore.setValue`'s type context is a column, not a pspec), but a thin `addSetter` override boxing to `pspec.valueType` can be layered on top of this later if an ambiguous case surfaces. This matches GJS behavior exactly.

## Test plan

- New `tests/conversion__gvalue_autobox.js` covering the requested matrix — boolean, int, double, string, enum, flags, GObject instance, boxed instance, explicit-`GObject.Value` passthrough, `Gtk.ListStore.setValue`, and an unboxable `{}` failing with a useful error. Driven through the raw introspected `g_object_set_property` (`_setProperty`).
- Verified the issue's exact repro against real GTK4 + libadwaita (raw boolean/int/string/enum through `Adw.Breakpoint.addSetter`, plus the hand-boxed workaround still working).
- Full suite: 101 passing; the one failure (`tests/require.js`) fails identically on untouched master here (Arch ships GIRepository-3.0) — environmental, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)